### PR TITLE
Fix unit test coverage dependency

### DIFF
--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -190,6 +190,8 @@ jobs:
           file: dockerfile/Dockerfile
           context: .
           push: true
+          build-args: |
+            INSTALL_TEST_DEPS=1
           cache-from: |
             ${{ steps.build-meta.outputs.cache-from }}
             ${{ steps.recent-pr-cache-refs.outputs.cache-from }}

--- a/dockerfile/Dockerfile
+++ b/dockerfile/Dockerfile
@@ -182,8 +182,10 @@ RUN T=$(python -c "import torch; print(torch.__version__)") && \
 # NOTE: nemo-automodel is intentionally NOT filtered out — it installs from the requirements.txt
 # git pin here, baking AutoModel into the image (self-contained for Docker Hub). The runtime
 # PYTHONPATH sibling-checkout override (above) takes precedence over this baked copy.
+ARG INSTALL_TEST_DEPS=0
 COPY requirements.txt /tmp/requirements.txt
-RUN python -m pip install "coverage[toml]" ftfy open_clip_torch timm wcwidth && \
+RUN if [ "$INSTALL_TEST_DEPS" = "1" ]; then python -m pip install coverage pytest; fi && \
+    python -m pip install ftfy open_clip_torch timm wcwidth && \
     grep -ivE '^[[:space:]]*(dion|vllm|torch|torchvision|torchaudio|transformer[-_]engine|flash[-_]attn|flash[-_]linear[-_]attention|fla([-_]core)?|mamba[-_]ssm|causal[-_]conv1d|deep[-_]ep|ray)([=<>!~ ]|$)' \
         /tmp/requirements.txt > /tmp/req.filtered.txt && \
     python -m pip install -c /opt/torch-pin.txt -r /tmp/req.filtered.txt && \

--- a/dockerfile/Dockerfile
+++ b/dockerfile/Dockerfile
@@ -183,7 +183,7 @@ RUN T=$(python -c "import torch; print(torch.__version__)") && \
 # git pin here, baking AutoModel into the image (self-contained for Docker Hub). The runtime
 # PYTHONPATH sibling-checkout override (above) takes precedence over this baked copy.
 COPY requirements.txt /tmp/requirements.txt
-RUN python -m pip install ftfy open_clip_torch timm wcwidth && \
+RUN python -m pip install "coverage[toml]" ftfy open_clip_torch timm wcwidth && \
     grep -ivE '^[[:space:]]*(dion|vllm|torch|torchvision|torchaudio|transformer[-_]engine|flash[-_]attn|flash[-_]linear[-_]attention|fla([-_]core)?|mamba[-_]ssm|causal[-_]conv1d|deep[-_]ep|ray)([=<>!~ ]|$)' \
         /tmp/requirements.txt > /tmp/req.filtered.txt && \
     python -m pip install -c /opt/torch-pin.txt -r /tmp/req.filtered.txt && \

--- a/tests/unit/launch_scripts/Launch_Unit_Tests.sh
+++ b/tests/unit/launch_scripts/Launch_Unit_Tests.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -xeuo pipefail
 
-coverage run --data-file="${COVERAGE_FILE:-.coverage}" --source=molt -m pytest tests/unit
+python -m coverage run --data-file="${COVERAGE_FILE:-.coverage}" --source=molt -m pytest tests/unit


### PR DESCRIPTION
## Summary
- add an optional Docker build arg for CI-only test dependencies
- enable that build arg for the CI image build so unit tests have pytest and coverage
- invoke coverage through python -m coverage in the unit launch script

## Testing
- bash -n tests/unit/launch_scripts/Launch_Unit_Tests.sh
- git diff --check -- .github/workflows/cicd-main.yml dockerfile/Dockerfile tests/unit/launch_scripts/Launch_Unit_Tests.sh