### PR TITLE
fix(experience): merge routed_experts when only some samples captured routing

### DIFF
--- a/molt/trainer/algorithm/experience.py
+++ b/molt/trainer/algorithm/experience.py
@@ -48,6 +48,28 @@ def get_model_parallel_size(args) -> int:
     return int(fsdp.cp_size) * int(fsdp.tp_size)
 
 
+def _fill_missing_routed_experts(items: List["Experience"]) -> None:
+    """In place: give samples with no captured routing a full -1 (natural-routing) block.
+
+    ``routed_experts`` is None for a rollout the engine returned no routing for. Batched
+    next to routed samples, the first-element merge dispatch would otherwise drop the batch's
+    routing (leading None) or crash on ``None.size(-1)`` (trailing None). Materialize the -1
+    sentinel sized to the sample's OWN sequence length (routed_experts is seq-aligned with
+    ``sequences``) so it pads to the same seq dim as everything else after concat/stack; -1
+    means "keep live routing" on every token, exactly "no captured routing". No-op unless
+    some — but not all — samples in the batch carry routing.
+    """
+    present = [it.routed_experts for it in items if it.routed_experts is not None]
+    if not present or len(present) == len(items):
+        return
+    layers_topk = present[0].shape[-3:-1]  # (num_moe_layers, topk), fixed by the model
+    dtype = present[0].dtype
+    for it in items:
+        if it.routed_experts is None:
+            seq = it.sequences  # (..., T); routed_experts is (..., num_moe_layers, topk, T)
+            it.routed_experts = torch.full((*seq.shape[:-1], *layers_topk, seq.shape[-1]), -1, dtype=dtype)
+
+
 @dataclass
 class Experience:
     """A batch of RL experience for policy optimization.
@@ -180,6 +202,11 @@ class Experience:
         # Create result dictionary
         result = {}
 
+        # A rollout with no captured routing has routed_experts=None; fill it (sized to its
+        # own sequence) before the field merge so a mix doesn't drop the batch's routing or
+        # crash on None.size(-1).
+        _fill_missing_routed_experts(experiences_list)
+
         # Merge all fields
         for name in field_names:
             values = [getattr(e, name) for e in experiences_list]
@@ -233,6 +260,11 @@ def make_experience_batch(items: List[Experience]) -> Experience:
     """Combine individual single-sample Experiences into a batched Experience."""
     if not items:
         raise ValueError("Empty items list")
+
+    # A rollout with no captured routing has routed_experts=None; fill it (sized to its own
+    # sequence) before batching so a mix doesn't drop the batch's routing or crash on
+    # None.size(-1).
+    _fill_missing_routed_experts(items)
 
     kwargs = {}
     for f in fields(Experience):

--- a/tests/unit/test_routing_replay.py
+++ b/tests/unit/test_routing_replay.py
@@ -28,7 +28,11 @@ import torch
 
 from molt.agents.base import Trajectory
 from molt.models.base import BaseModel
-from molt.trainer.algorithm.experience import Experience, make_experience_batch, remove_padding_in_sequences
+from molt.trainer.algorithm.experience import (
+    Experience,
+    make_experience_batch,
+    remove_padding_in_sequences,
+)
 
 L, K = 3, 2  # MoE layers, top-k
 
@@ -234,3 +238,66 @@ def test_build_routing_targets_cp_pads_with_sentinel():
         assert targets[layer].shape == (2, K)
         assert targets[layer][0, 0].item() == 10 * layer + 2  # global pos 1 (real)
         assert (targets[layer][1] == -1).all()  # global pos 2 (pad -> sentinel)
+
+
+def test_make_experience_batch_mixed_none_routed_experts():
+    # A batch mixing a captured-routing sample with an unrouted (None) one must neither
+    # silently drop the batch's routing (leading None -> first-item dispatch returned None)
+    # nor crash on None.size(-1) (trailing None). The None sample becomes an all-(-1)
+    # sentinel block: natural routing on every token, i.e. exactly "no captured routing".
+    routed = torch.zeros(L, K, 3, dtype=torch.int16)
+    have = Experience(sequences=torch.tensor([1, 2, 3]), attention_mask=torch.tensor([1, 1, 1]), routed_experts=routed)
+    missing = Experience(
+        sequences=torch.tensor([4, 5, 6]), attention_mask=torch.tensor([1, 1, 1]), routed_experts=None
+    )
+
+    trailing = make_experience_batch([have, missing])  # trailing None used to crash
+    assert trailing.routed_experts.shape == (2, L, K, 3)
+    assert torch.equal(trailing.routed_experts[0], routed)
+    assert (trailing.routed_experts[1] == -1).all()
+
+    leading = make_experience_batch([missing, have])  # leading None used to drop the batch's routing
+    assert leading.routed_experts.shape == (2, L, K, 3)
+    assert (leading.routed_experts[0] == -1).all()
+    assert torch.equal(leading.routed_experts[1], routed)
+
+
+def test_make_experience_batch_none_routed_experts_longest_stays_seq_aligned():
+    # The unrouted (None) sample is the LONGEST: its synthesized sentinel must carry its own
+    # sequence length, or routed_experts would pad to a shorter seq dim than `sequences` and
+    # desync from the token axis the training forward replays against.
+    have = Experience(
+        sequences=torch.tensor([1, 2]),
+        attention_mask=torch.tensor([1, 1]),
+        routed_experts=torch.zeros(L, K, 2, dtype=torch.int16),
+    )
+    missing = Experience(sequences=torch.tensor([3, 4, 5, 6]), attention_mask=torch.tensor([1, 1, 1, 1]))
+    batch = make_experience_batch([have, missing])
+
+    assert batch.sequences.shape == (2, 4)
+    assert batch.routed_experts.shape == (2, L, K, 4)  # seq dim matches sequences, not the routed sample's 2
+    assert (batch.routed_experts[1] == -1).all()
+
+
+def test_make_experience_batch_all_none_routed_experts_stays_none():
+    a = Experience(sequences=torch.tensor([1, 2]), attention_mask=torch.tensor([1, 1]), routed_experts=None)
+    b = Experience(sequences=torch.tensor([3, 4]), attention_mask=torch.tensor([1, 1]), routed_experts=None)
+    assert make_experience_batch([a, b]).routed_experts is None
+
+
+def test_concat_experiences_mixed_none_routed_experts():
+    # The make_experience micro-batch path (concat_experiences over single-sample (1, ...)
+    # experiences) hits the same first-item dispatch. A None among tensors must merge, seq-
+    # aligned with sequences and right-padded by the -1 sentinel, not drop the batch or crash.
+    routed = torch.zeros(1, L, K, 2, dtype=torch.int16)
+    have = Experience(sequences=torch.tensor([[1, 2]]), attention_mask=torch.tensor([[1, 1]]), routed_experts=routed)
+    missing = Experience(  # leading None AND the longest sequence
+        sequences=torch.tensor([[3, 4, 5]]), attention_mask=torch.tensor([[1, 1, 1]]), routed_experts=None
+    )
+
+    merged = Experience.concat_experiences([missing, have], pad_token_id=0)
+    assert merged.sequences.shape == (2, 3)
+    assert merged.routed_experts.shape == (2, L, K, 3)  # seq dim tracks sequences
+    assert (merged.routed_experts[0] == -1).all()  # unrouted sample -> natural routing everywhere
+    assert (merged.routed_experts[1, :, :, :2] == 0).all()  # captured rows preserved
+    assert (merged.routed_experts[1, :, :, 2] == -1).all()  # its pad tail -> sentinel


### PR DESCRIPTION
## Problem

`Experience._merge_item` and `make_experience_batch` dispatch the per-field merge on the **first** sample's type. `routed_experts` (R3 rollout routing replay) is per-sample either a `(1, num_moe_layers, topk, T)` tensor or `None`. When a micro-batch mixes the two, the first-element dispatch fails two ways depending on ordering:

- **Leading `None`** → the merge returns `None`, silently discarding the captured routing of every other sample in the micro-batch. R3 replay is defeated for the whole micro-batch, so train and rollout routing diverge again (exactly what R3 exists to prevent).
- **Trailing `None`** → `zero_pad_sequences` calls `None.size(-1)` and raises `AttributeError`, crashing `make_experience`.

### Reachability

A rollout carries `routed_experts=None` whenever the engine returns no routing array for a non-empty completion (`RouterGenerateClient` yields `None`, `absorb_routing` early-returns, the sample stays `None`). With `routing_replay` on, sibling rollouts do carry routing, so the mix is reachable, and it lands in the `balance_experiences` → `make_experience_batch` path that runs every training step. The `pad_value=-1` sentinel already wired for `routed_experts` shows mixed-length merges are intended; only the `None` case was unhandled.

## Fix

Before the field merge (in both `concat_experiences` and `make_experience_batch`), fill any missing `routed_experts` with the `-1` sentinel — "keep live routing" on every token, which is exactly "no captured routing" — **sized to that sample's own sequence length** so it stays seq-aligned with `sequences` after right-pad/concat. No-op unless some but not all samples in the batch carry routing; an all-`None` batch still merges to `None`.

Sizing to the sample's own length matters: a zero-length placeholder would let a longer unrouted sample pad `routed_experts` to a shorter seq dim than `sequences`, desyncing the token axis the training forward replays against.

## Tests

Added to `tests/unit/test_routing_replay.py` (all pass, plus the pre-existing 10):

- mixed `None`/tensor in both orders → no crash, no silent drop, unrouted sample becomes all `-1`
- unrouted sample is the **longest** → `routed_experts` seq dim tracks `sequences` (the alignment guard)
- `concat_experiences` mixed path with the unrouted sample longest
- all-`None` still merges to `None`

```
$ python -m pytest -q tests/unit/test_routing_replay.py tests/unit/test_experience.py
20 passed
```

`ruff check` / `ruff format --check` clean on the changed files; `python -m compileall -q molt tests` clean.
