### PR TITLE
fix(rollout): preserve router HTTP error detail

### DIFF
--- a/molt/trainer/rollout/router.py
+++ b/molt/trainer/rollout/router.py
@@ -226,7 +226,24 @@ class RouterGenerateClient:
         for attempt in range(retries):
             try:
                 async with self.http.post(path, json=body, headers=headers) as resp:
-                    resp.raise_for_status()
+                    try:
+                        resp.raise_for_status()
+                    except aiohttp.ClientResponseError as exc:
+                        # aiohttp's default exception only reports ``400 Bad
+                        # Request`` and discards vLLM's actionable JSON body
+                        # (for example, the exact multimodal image limit).
+                        # Preserve that detail so a bad rollout fails once with
+                        # a diagnosable error instead of looking transient.
+                        read_text = getattr(resp, "text", None)
+                        detail = ""
+                        if callable(read_text):
+                            try:
+                                detail = (await read_text()).strip()
+                            except Exception:
+                                detail = ""
+                        if detail:
+                            exc.message = f"{exc.message}: {detail[:2048]}"
+                        raise
                     return await resp.json()
             except (aiohttp.ClientResponseError, aiohttp.ClientConnectionError) as e:
                 fatal = isinstance(e, aiohttp.ClientResponseError) and e.status < 500  # 4xx = real bug

--- a/tests/unit/test_router.py
+++ b/tests/unit/test_router.py
@@ -67,22 +67,27 @@ class _FakeHttp:
 
 
 class _RaisingResp:
-    def __init__(self, exc):
+    def __init__(self, exc, body=""):
         self._exc = exc
+        self._body = body
 
     def raise_for_status(self):
         raise self._exc
+
+    async def text(self):
+        return self._body
 
     async def json(self):
         return {}
 
 
 class _RaisingCtx:
-    def __init__(self, exc):
+    def __init__(self, exc, body=""):
         self._exc = exc
+        self._body = body
 
     async def __aenter__(self):
-        return _RaisingResp(self._exc)
+        return _RaisingResp(self._exc, self._body)
 
     async def __aexit__(self, *a):
         return False
@@ -91,13 +96,17 @@ class _RaisingCtx:
 class _FlakyHttp:
     """Fails the first ``fail_times`` POSTs with ``exc``, then serves ``payload``."""
 
-    def __init__(self, payload, exc, fail_times):
-        self.payload, self.exc, self.fail_times = payload, exc, fail_times
+    def __init__(self, payload, exc, fail_times, body=""):
+        self.payload, self.exc, self.fail_times, self.body = payload, exc, fail_times, body
         self.attempts = 0
 
     def post(self, url, json=None, headers=None):
         self.attempts += 1
-        return _RaisingCtx(self.exc) if self.attempts <= self.fail_times else _FakeCtx(self.payload)
+        return (
+            _RaisingCtx(self.exc, self.body)
+            if self.attempts <= self.fail_times
+            else _FakeCtx(self.payload)
+        )
 
 
 def _sp():
@@ -184,6 +193,24 @@ def test_post_fails_fast_on_4xx(monkeypatch):
     http = _FlakyHttp(_gen_resp([90]), aiohttp.ClientResponseError(None, (), status=400), fail_times=10)
     with pytest.raises(aiohttp.ClientResponseError):
         asyncio.run(RouterGenerateClient(http).generate([1, 2], _sp()))
+    assert http.attempts == 1
+
+
+def test_post_includes_vllm_error_body_in_4xx(monkeypatch):
+    async def _no_sleep(*_a, **_k):
+        pass
+
+    monkeypatch.setattr("molt.trainer.rollout.router.asyncio.sleep", _no_sleep)
+    body = '{"error":{"message":"At most 9 image(s) may be provided in one prompt."}}'
+    http = _FlakyHttp(
+        _gen_resp([90]),
+        aiohttp.ClientResponseError(None, (), status=400, message="Bad Request"),
+        fail_times=10,
+        body=body,
+    )
+    with pytest.raises(aiohttp.ClientResponseError) as caught:
+        asyncio.run(RouterGenerateClient(http).generate([1, 2], _sp()))
+    assert "At most 9 image" in caught.value.message
     assert http.attempts == 1
 
 


### PR DESCRIPTION
## What changed

- Preserve up to 2 KiB of the HTTP response body when the vLLM router returns an error.
- Keep the existing retry behavior: 4xx responses still fail immediately, while transient failures retain their current handling.
- Add coverage for actionable vLLM validation details returned in a 400 response.

## Why

`aiohttp.ClientResponseError` reports only the status and reason by default. The vLLM response body contains the useful diagnosis, such as the exact multimodal image limit, so dropping it turns a deterministic bad request into an opaque `400 Bad Request` failure.

## Impact

Rollout failures now surface the server-provided detail without changing successful requests or retry policy. Response text is capped at 2048 characters to keep exceptions bounded.

## Validation

- `PYTHONPATH=. .venv/bin/python -m pytest -q tests/unit/test_router.py` (12 passed)
- `git diff --check`

Signed-off-by: Zhiqi Li <lzq@smail.nju.edu.cn>
