### PR TITLE
feat(observability): log adaptive KL coefficient to status

### DIFF
--- a/molt/trainer/rl_trainer.py
+++ b/molt/trainer/rl_trainer.py
@@ -369,6 +369,12 @@ class BaseRLTrainer:
             self.broadcast_to_vllm()
         broadcast_time = time.time() - t0
 
+        # Log the KL coefficient applied to this step's loss (the value passed into
+        # `fit`), captured before the update below mutates it. Without this, adaptive-KL
+        # runs (--algo.kl.target set) surface the measured `kl` but not the coefficient
+        # the AdaptiveKLController is driving in response — the feedback loop is invisible.
+        status["kl_coef"] = self.kl_ctl.value
+
         # Refresh KL controller with the latest measurement (no-op for FixedKLController).
         if "kl" in status:
             self.kl_ctl.update(status["kl"], self.args.rollout.batch_size * self.args.rollout.n_samples_per_prompt)


### PR DESCRIPTION
Adaptive-KL runs (`--algo.kl.target` set) surface the measured `kl` but not the coefficient the AdaptiveKLController drives in response, so the feedback loop is invisible in metrics. Record `status["kl_coef"]` with the coefficient applied to this step's loss (the value passed into `fit`, captured before the controller update mutates it). No-op-safe for FixedKLController, which reports its constant coef.