### PR TITLE
fix(agents): preserve Anthropic system prompts

### DIFF
--- a/molt/agents/_chat_server.py
+++ b/molt/agents/_chat_server.py
@@ -96,9 +96,9 @@ def _content_to_text_and_images(content) -> tuple[str, list]:
 
 def _decode_anthropic(body: dict) -> dict:
     """Anthropic Messages request -> canonical (OpenAI-shaped) body the router
-    understands. Only content blocks + (already same-named) sampling fields are
-    touched; top-level ``system`` is left inert."""
-    messages = []
+    understands. Top-level ``system`` becomes the first canonical message; content
+    blocks are normalized below."""
+    messages = [{"role": "system", "content": body["system"]}] if body.get("system") else []
     for m in body.get("messages", []):
         content = m.get("content")
         if isinstance(content, list):

--- a/tests/unit/test_chat_server.py
+++ b/tests/unit/test_chat_server.py
@@ -523,9 +523,21 @@ def test_decode_anthropic_normalizes_to_openai_shape():
         ],
     }
     out = _decode_anthropic(body)
-    assert all(m["role"] != "system" for m in out["messages"]) and len(out["messages"]) == 2
-    blocks = out["messages"][1]["content"]
+    assert out["messages"][0] == {"role": "system", "content": "sys"}
+    assert len(out["messages"]) == 3
+    blocks = out["messages"][2]["content"]
     assert blocks[1] == {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}}
+
+
+def test_decode_anthropic_system_blocks_reach_template_input():
+    body = {
+        "system": [{"type": "text", "text": "Be concise."}],
+        "messages": [{"role": "user", "content": "hi"}],
+    }
+    out = _decode_anthropic(body)
+    chat, images = cs._messages_to_chat(SimpleNamespace(expand_image_placeholder=False), out["messages"])
+    assert chat == [{"role": "system", "content": "Be concise."}, {"role": "user", "content": "hi"}]
+    assert images == []
 
 
 def test_decode_anthropic_unwraps_tool_result():


### PR DESCRIPTION
## Summary

Anthropic clients send system instructions in the top-level `system` field.
`_run_turn()` renders the normalized `messages` list, but
`_decode_anthropic()` left `system` outside it. The request still succeeded,
with the instruction missing from the model input.

`_decode_anthropic()` now prepends the instruction to `messages`. The tests
cover the two forms accepted by the Anthropic SDK: a string and a list of text
blocks. Requests without `system` still follow the existing path.

## Testing

- `python -m pytest -q tests/unit/test_chat_server.py -k decode_anthropic`
- `python -m pytest -q` (`155 passed`)
- `python -m compileall -q molt examples/python tests`
- pre-commit on the changed files
