### PR TITLE
fix(rollout): deduplicate scores after context compaction

### DIFF
--- a/molt/trainer/rollout/samples_generator.py
+++ b/molt/trainer/rollout/samples_generator.py
@@ -249,7 +249,7 @@ class SamplesGenerator:
             rollout_metrics["rollout/dropped/total"] = float(sum(drop_counts.values()))
         if dynamic_filtering and prompts_dispatched:
             rollout_metrics["dynamic_filtering_pass_rate"] = groups_accepted / prompts_dispatched * 100
-        # Pre-filter stats: the model's TRUE judge pass rate over ALL scored samples, BEFORE DAPO
+        # Pre-filter stats: the model's TRUE judge pass rate over ALL scored rollouts, BEFORE DAPO
         # drops uniform groups. (post-filter `reward`/`pivotrl_correct` only covers kept MIXED groups
         # ~0.5-0.65 by construction, so it hides the real pass rate + the all-pass saturation.)
         if score_stats.get("score_n", 0) > 0:
@@ -275,15 +275,15 @@ class SamplesGenerator:
         exhausted = self._dataloader_iter is None and not self._finished_samples and not self._inflight_rollouts
         return batch_samples, rollout_metrics, prompts_dispatched, exhausted
 
-    def _passes_dynamic_filter(self, group_samples) -> bool:
-        """Whether a scored group's mean reward lands inside the dynamic-filtering range.
+    def _passes_dynamic_filter(self, rollout_samples) -> bool:
+        """Whether a scored group's mean rollout reward lands inside the dynamic-filtering range.
 
-        A group with any unscored sample always passes — filtering only applies once
-        every sample in the group has a score.
+        A group with any unscored rollout always passes — filtering only applies once
+        every rollout in the group has a score.
         """
-        if not all(s.scores is not None for s in group_samples):
+        if not all(s.scores is not None for s in rollout_samples):
             return True
-        scores = [s.scores[0].item() for s in group_samples]
+        scores = [s.scores[0].item() for s in rollout_samples]
         mean_score = sum(scores) / len(scores)
         min_score, max_score = self.args.algo.dynamic_filtering_range
         if min_score < mean_score < max_score:
@@ -321,11 +321,16 @@ class SamplesGenerator:
                 drop_counts[drop_reason] += 1
 
         if dynamic_filtering and group_samples:
-            # Pre-filter score stats (the model's TRUE judge pass rate over scored samples, BEFORE
+            # Compaction can emit several step-samples with the same terminal score. Keep one
+            # representative per rollout for filtering; all segments still enter training below.
+            rollout_samples = {
+                (s.rollout_ids[0] if getattr(s, "rollout_ids", None) else id(s)): s for s in group_samples
+            }.values()
+            # Pre-filter score stats (the model's TRUE judge pass rate over scored rollouts, BEFORE
             # DAPO drops uniform groups). Accumulate here, before any keep/drop decision, so the
             # logged mean reflects all-pass + all-fail + mixed (not just the kept mixed groups).
             if score_stats is not None:
-                scored = [s.scores[0].item() for s in group_samples if s.scores is not None]
+                scored = [s.scores[0].item() for s in rollout_samples if s.scores is not None]
                 if scored:
                     min_score, max_score = self.args.algo.dynamic_filtering_range
                     gmean = sum(scored) / len(scored)
@@ -341,15 +346,11 @@ class SamplesGenerator:
             # -> NCCL collective desync/hang. Drop+backfill the whole group so each accepted group
             # contributes exactly n_samples (batch stays a clean groups_per_batch * n_samples).
             n_samples = generate_kwargs.get("n_samples_per_prompt", self.args.rollout.n_samples_per_prompt)
-            # Count ROLLOUTS, not step-samples: a multi-turn / context-compacting agent emits
-            # several step-samples per rollout sharing one rollout_id (see experience.py), so
-            # len(group_samples) over-counts and a group that actually lost a rollout could still
-            # pass this completeness check. Count distinct rollout_ids (single-turn: 1 each, == old).
-            n_rollouts = len({(s.rollout_ids[0] if getattr(s, "rollout_ids", None) else id(s)) for s in group_samples})
+            n_rollouts = len(rollout_samples)
             if n_rollouts < n_samples:
                 drop_counts["incomplete_group"] += len(group_samples)
                 return []
-            if not self._passes_dynamic_filter(group_samples):
+            if not self._passes_dynamic_filter(rollout_samples):
                 drop_counts["dynamic_filter"] += len(group_samples)
                 return []
         return group_samples

--- a/tests/unit/test_samples_generator.py
+++ b/tests/unit/test_samples_generator.py
@@ -15,6 +15,7 @@
 
 import sys
 import types
+from collections import defaultdict
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
@@ -218,6 +219,26 @@ def test_generate_samples_drops_filtered_groups_and_refills_their_slots(monkeypa
     # The filtered group is tallied by reason for observability.
     assert rollout_metrics["rollout/dropped/dynamic_filter"] == 1.0
     assert rollout_metrics["rollout/dropped/total"] == 1.0
+
+
+def test_dynamic_filtering_counts_compaction_segments_once_per_rollout(monkeypatch):
+    generator = object.__new__(SamplesGenerator)
+    generator.args = SimpleNamespace(
+        rollout=SimpleNamespace(n_samples_per_prompt=2),
+        algo=SimpleNamespace(dynamic_filtering_range=(0.4, 0.6)),
+    )
+    samples = [
+        SimpleNamespace(rollout_ids=[rollout_id], scores=torch.tensor([score]))
+        for rollout_id, score in [("a", 1.0), ("a", 1.0), ("a", 1.0), ("b", 0.0)]
+    ]
+    generator._process_response_into_experience = lambda response, **kwargs: (response, None)
+    monkeypatch.setattr(samples_generator.ray, "get", lambda _: samples)
+    score_stats = defaultdict(float)
+
+    kept = generator._filter_group(object(), True, defaultdict(int), score_stats=score_stats)
+
+    assert kept == samples
+    assert dict(score_stats) == {"score_sum": 1.0, "score_n": 2, "groups": 1.0, "all_pass": 0.0, "all_fail": 0.0}
 
 
 def test_process_response_counts_only_action_tokens_for_multiturn_lengths():


### PR DESCRIPTION
## Summary

Context compaction can split one rollout into several step samples. Every
segment carries the same `rollout_id` and terminal score. The completeness
check already counts distinct rollouts, but the dynamic filtering mean score
and pre-filter metrics counted each segment. This gave extra weight to rollouts
with more segments and could change whether a group passed the filter.

Dynamic filtering now uses one representative sample per `rollout_id`. All
segments are still returned for training. The regression test uses two rollout
scores, `1.0` and `0.0`, with the first split into three segments. The mean is
`0.5`, not the segment-weighted `0.75`.

## Testing

- `python -m pytest -q tests/unit/test_samples_generator.py` (`9 passed`)
- `python -m pytest -q` (`156 passed`)
- `python -m compileall -q molt examples/python tests`
- pre-commit on the changed files
