### PR TITLE
Fix best checkpoints during async evaluation

### DIFF
--- a/examples/scripts/quick_start/rl_qwen3_4b.sh
+++ b/examples/scripts/quick_start/rl_qwen3_4b.sh
@@ -109,7 +109,7 @@ python3 -u -m molt.cli.train_rl_ray \
   --eval.n_samples_per_prompt 1 \
   --ckpt.output_dir "$SAVE_ROOT/hf" \
   --ckpt.path "$SAVE_ROOT/state" \
-  --ckpt.save_steps 5 \
+  --ckpt.save_steps 1 \
   --logger.logging_steps 1 \
   --logger.wandb.project "${WANDB_PROJECT:-molt_quickstart_qwen3_4b}" \
   --logger.wandb.run_name "${WANDB_RUN_NAME:-qwen3_4b_quickstart_$$}"

--- a/examples/scripts/quick_start/rl_qwen3_6_35b.sh
+++ b/examples/scripts/quick_start/rl_qwen3_6_35b.sh
@@ -121,7 +121,7 @@ python3 -u -m molt.cli.train_rl_ray \
   --eval.n_samples_per_prompt 1 \
   --ckpt.output_dir "$SAVE_ROOT/hf" \
   --ckpt.path "$SAVE_ROOT/state" \
-  --ckpt.save_steps 5 \
+  --ckpt.save_steps 1 \
   --logger.logging_steps 1 \
   --logger.wandb.project "${WANDB_PROJECT:-molt_quickstart_qwen3_6}" \
   --logger.wandb.run_name "${WANDB_RUN_NAME:-qwen3_6_quickstart_$$}"

--- a/examples/scripts/slurm/rl_glm5_2_753b.sh
+++ b/examples/scripts/slurm/rl_glm5_2_753b.sh
@@ -423,6 +423,7 @@ RL_ARGS=(
   --ckpt.output_dir "$SAVE_ROOT/hf"
   --ckpt.path "$SAVE_ROOT/state"
   --ckpt.save_steps "${SAVE_STEPS:-5}"
+  --ckpt.best_metric_key none
   --ckpt.max_num "${CKPT_MAX_NUM:-50}"
   --logger.logging_steps 1
   --logger.wandb.project "${WANDB_PROJECT:-molt_async_visual_rl}"

--- a/examples/scripts/slurm/rl_omni3_30b.sh
+++ b/examples/scripts/slurm/rl_omni3_30b.sh
@@ -71,7 +71,7 @@ export OPTIM="${OPTIM:-adam}"
 export LR="${LR:-2e-6}"
 
 # --- Eval / checkpoint ------------------------------------------------------
-export SAVE_STEPS="${SAVE_STEPS:-2}"
+export SAVE_STEPS="${SAVE_STEPS:-1}"
 export EVAL_STEPS="${EVAL_STEPS:-10}"
 export EVAL_N_SAMPLES_PER_PROMPT="${EVAL_N_SAMPLES_PER_PROMPT:-1}"
 # Off by default: a step-0 baseline eval holds the rollout engines for the whole
@@ -431,7 +431,7 @@ RL_ARGS=(
   --reward.clip_range -1 1
   --ckpt.output_dir "$SAVE_ROOT/hf"
   --ckpt.path "$SAVE_ROOT/state"
-  --ckpt.save_steps "${SAVE_STEPS:-5}"
+  --ckpt.save_steps "${SAVE_STEPS:-1}"
   --ckpt.max_num "${CKPT_MAX_NUM:-50}"
   --logger.logging_steps 1
   --logger.wandb.project "${WANDB_PROJECT:-molt_async_visual_rl}"

--- a/examples/scripts/slurm/rl_qwen3_4b.sh
+++ b/examples/scripts/slurm/rl_qwen3_4b.sh
@@ -312,7 +312,7 @@ RL_ARGS=(
   --reward.clip_range -10 10
   --ckpt.output_dir "$SAVE_ROOT/hf"
   --ckpt.path "$SAVE_ROOT/state"
-  --ckpt.save_steps "${SAVE_STEPS:-5}"
+  --ckpt.save_steps "${SAVE_STEPS:-1}"
   --logger.logging_steps 1
   --logger.wandb.project "${WANDB_PROJECT:-molt_async_visual_rl}"
   --logger.wandb.run_name "${WANDB_RUN_NAME:-visual_rl_$SLURM_JOB_ID}"

--- a/examples/scripts/slurm/rl_qwen3_6_35b.sh
+++ b/examples/scripts/slurm/rl_qwen3_6_35b.sh
@@ -431,7 +431,7 @@ RL_ARGS=(
   --reward.clip_range -10 10
   --ckpt.output_dir "$SAVE_ROOT/hf"
   --ckpt.path "$SAVE_ROOT/state"
-  --ckpt.save_steps "${SAVE_STEPS:-5}"
+  --ckpt.save_steps "${SAVE_STEPS:-1}"
   --ckpt.max_num "${CKPT_MAX_NUM:-50}"
   --logger.logging_steps 1
   --logger.wandb.project "${WANDB_PROJECT:-molt_async_visual_rl}"

--- a/molt/trainer/rl_trainer.py
+++ b/molt/trainer/rl_trainer.py
@@ -15,6 +15,7 @@
 
 import asyncio
 import os
+import shutil
 import statistics
 import time
 from typing import Dict, Tuple
@@ -297,20 +298,58 @@ class BaseRLTrainer:
         # Best eval metric tracking
         self.best_eval_metric_value = float("-inf")
         self.best_eval_metric_key = getattr(self.args.ckpt, "best_metric_key", "") or ""
-        self._latest_eval_metric_value = None
 
     def restore_best_metric_tracker(self, checkpoint_states) -> None:
-        if not checkpoint_states:
+        if not getattr(self.args.ckpt, "load_enable", False):
             return
 
-        checkpoint_metric_key = checkpoint_states.get("best_eval_metric_key")
-        checkpoint_metric_value = checkpoint_states.get("best_eval_metric_value")
+        states = [checkpoint_states or {}]
+        actor_root = os.path.join(self.args.ckpt.path, "_actor")
+        if os.path.isdir(actor_root):
+            for name in os.listdir(actor_root):
+                path = os.path.join(actor_root, name)
+                if (
+                    name.startswith("best_global_step")
+                    and not name.endswith((".tmp", ".old"))
+                    and self.strategy.checkpoint._is_loadable_ckpt_dir(path)
+                ):
+                    try:
+                        states.append(
+                            torch.load(os.path.join(path, "extra_state.pt"), weights_only=False)["client_state"]
+                        )
+                    except (KeyError, OSError, RuntimeError, EOFError) as exc:
+                        logger.warning(f"Ignoring unreadable best-checkpoint metadata at {path}: {exc}")
 
-        if checkpoint_metric_key:
-            self.best_eval_metric_key = checkpoint_metric_key
-        if checkpoint_metric_value is not None:
+        for state in states:
+            checkpoint_metric_key = state.get("best_eval_metric_key")
+            checkpoint_metric_value = state.get("best_eval_metric_value")
+            if checkpoint_metric_value is None or checkpoint_metric_value <= self.best_eval_metric_value:
+                continue
+            if checkpoint_metric_key:
+                self.best_eval_metric_key = checkpoint_metric_key
             self.best_eval_metric_value = checkpoint_metric_value
-            self._latest_eval_metric_value = checkpoint_metric_value
+        self._prune_hf_checkpoints()
+
+    def _prune_hf_checkpoints(self) -> None:
+        """Keep HF snapshots aligned with retained actor checkpoints."""
+        if not getattr(self.args.ckpt, "save_hf", False):
+            return
+
+        actor_root = os.path.join(self.args.ckpt.path, "_actor")
+        if not os.path.isdir(actor_root):
+            return
+        retained_tags = {
+            name
+            for name in os.listdir(actor_root)
+            if (name.startswith("global_step") or name.startswith("best_global_step"))
+            and self.strategy.checkpoint._is_loadable_ckpt_dir(os.path.join(actor_root, name))
+        }
+        for name in os.listdir(self.args.ckpt.path):
+            if not name.endswith("_hf"):
+                continue
+            tag = name[:-3]
+            if (tag.startswith("global_step") or tag.startswith("best_global_step")) and tag not in retained_tags:
+                shutil.rmtree(os.path.join(self.args.ckpt.path, name), ignore_errors=True)
 
     def fit(self, global_step: int = 0) -> None:
         raise NotImplementedError("fit method is not implemented")
@@ -392,16 +431,16 @@ class BaseRLTrainer:
         status["actor_frozen"] = float(actor_frozen)
         policy_train_time = time.time() - t0
 
-        # Sync weights to vLLM (skipped while the actor is frozen: its weights are
-        # unchanged, so the live vLLM copy is already current).
+        # Sync changed weights to vLLM. Frozen steps only publish the new logical
+        # policy step under the lock because the actor weights did not change.
         t0 = time.time()
         # Reset per-step so a frozen/skipped broadcast reports 0 (not a stale
         # value); the TrainingActor.broadcast_to_vllm override sets these when
         # it runs (lock-wait vs actual transfer).
         self._broadcast_lock_wait_s = 0.0
         self._broadcast_transfer_s = 0.0
-        if self.vllm_engines is not None and not actor_frozen:
-            self.broadcast_to_vllm()
+        if self.vllm_engines is not None:
+            self.broadcast_to_vllm(global_step + 1, refit=not actor_frozen)
         broadcast_time = time.time() - t0
 
         # Log the KL coefficient applied to this step's loss (the value passed into
@@ -466,19 +505,28 @@ class BaseRLTrainer:
             ray.get(self.critic_model_group.async_run_method(method_name="empty_cache"))
         return status
 
-    def broadcast_to_vllm(self) -> None:
+    def broadcast_to_vllm(self, policy_step=None, refit=True) -> None:
         """Broadcast actor weights to vLLM engines."""
-        ray.get(self.actor_model_group.async_run_method(method_name="broadcast_to_vllm"))
+        if refit:
+            ray.get(self.actor_model_group.async_run_method(method_name="broadcast_to_vllm"))
 
         # NOTE: We keep vLLM in weights-only state after weight sync.
         # KV cache will be woken up before generation in SamplesGenerator.
 
-    def save_best_checkpoint(self, eval_metrics, global_step, client_states=None):
+    def save_best_checkpoint(self, eval_metrics, global_step, client_states=None, source_tag=None):
         """Save checkpoint if eval metric is the best so far.
 
         When best_metric_key is 'none' or no eval_*_pass1 metric is present,
         this is a no-op — regular save_steps checkpoints still save the most recent.
         """
+        if getattr(self.args.train, "partial_rollout_enable", False):
+            if eval_metrics and self.best_eval_metric_key != "none":
+                logger.warning(
+                    "Skipping best-checkpoint selection with partial rollouts: "
+                    "one evaluation can span multiple policy versions."
+                )
+            return
+
         if not eval_metrics or self.best_eval_metric_key == "none":
             return
 
@@ -487,28 +535,92 @@ class BaseRLTrainer:
         else:
             # Auto-detect: prefer eval_*_pass1 metric.
             metric_key = next((k for k in sorted(eval_metrics) if k.endswith("_pass1")), None)
-            if metric_key is not None:
-                self.best_eval_metric_key = metric_key
         if metric_key is None:
             return
 
         current_value = eval_metrics[metric_key]
-        self._latest_eval_metric_value = current_value
-        prev_best = self.best_eval_metric_value
+        if not (current_value > self.best_eval_metric_value):
+            return
 
-        if current_value > self.best_eval_metric_value:
-            self.best_eval_metric_value = current_value
-            logger.info(
-                f"New best eval metric: {metric_key}={current_value:.4f} at step {global_step} "
-                f"(previous best: {prev_best if prev_best > float('-inf') else 'N/A'})"
-            )
+        tag = f"best_global_step{global_step}"
+        client_state_updates = {
+            "best_eval_metric_key": metric_key,
+            "best_eval_metric_value": current_value,
+            "checkpoint_metric_key": metric_key,
+        }
+        if source_tag is not None:
+            checkpoint_roots = [os.path.join(self.args.ckpt.path, "_actor")]
+            if self.critic_model_group is not None:
+                checkpoint_roots.append(os.path.join(self.args.ckpt.path, "_critic"))
+            copies = [(os.path.join(root, source_tag), os.path.join(root, tag), root) for root in checkpoint_roots]
+            if self.args.ckpt.save_hf:
+                copies.append(
+                    (
+                        os.path.join(self.args.ckpt.path, f"{source_tag}_hf"),
+                        os.path.join(self.args.ckpt.path, f"{tag}_hf"),
+                        None,
+                    )
+                )
+            missing = [source for source, _, _ in copies if not os.path.isdir(source)]
+            if missing:
+                logger.warning(
+                    f"Skipping best checkpoint for eval step {global_step}: matching saved checkpoint "
+                    f"{source_tag} is unavailable. Align --ckpt.save_steps with --eval.steps."
+                )
+                return
 
-            client_states = client_states or {}
-            client_states["best_eval_metric_key"] = metric_key
-            client_states["best_eval_metric_value"] = current_value
-            client_states["checkpoint_metric_key"] = metric_key
+            for _, best_path, _ in copies:
+                pending_path = f"{best_path}.tmp"
+                backup_path = f"{best_path}.old"
+                shutil.rmtree(pending_path, ignore_errors=True)
+                if os.path.exists(backup_path):
+                    if os.path.exists(best_path):
+                        shutil.rmtree(backup_path, ignore_errors=True)
+                    else:
+                        os.replace(backup_path, best_path)
 
-            tag = f"best_global_step{global_step}"
+            published = []
+            backups = []
+            try:
+                for source_path, best_path, checkpoint_root in copies:
+                    pending_path = f"{best_path}.tmp"
+                    shutil.copytree(source_path, pending_path)
+                    if checkpoint_root is not None:
+                        extra_state_path = os.path.join(pending_path, "extra_state.pt")
+                        extra = torch.load(extra_state_path, weights_only=False)
+                        extra.setdefault("client_state", {}).update(client_state_updates)
+                        self.strategy.checkpoint._atomic_write_torch(extra_state_path, extra)
+                        self.strategy.checkpoint._write_ckpt_metric(pending_path, current_value, metric_key)
+
+                # The actor checkpoint is the durable commit marker read on resume,
+                # so publish it only after the critic and HF export are in place.
+                for _, best_path, _ in copies[1:] + copies[:1]:
+                    pending_path = f"{best_path}.tmp"
+                    backup_path = f"{best_path}.old"
+                    if os.path.exists(best_path):
+                        os.replace(best_path, backup_path)
+                        backups.append((best_path, backup_path))
+                    os.replace(pending_path, best_path)
+                    published.append(best_path)
+            except BaseException:
+                for best_path in reversed(published):
+                    shutil.rmtree(best_path, ignore_errors=True)
+                for best_path, backup_path in reversed(backups):
+                    if os.path.exists(backup_path):
+                        os.replace(backup_path, best_path)
+                raise
+            finally:
+                for _, best_path, _ in copies:
+                    shutil.rmtree(f"{best_path}.tmp", ignore_errors=True)
+
+            for _, backup_path in backups:
+                shutil.rmtree(backup_path, ignore_errors=True)
+            for _, _, checkpoint_root in copies:
+                if checkpoint_root is not None:
+                    self.strategy.checkpoint._prune_checkpoints(checkpoint_root, tag, 0, 0, is_best=True)
+        else:
+            client_states = dict(client_states or {})
+            client_states.update(client_state_updates)
             refs = self.actor_model_group.async_run_method(
                 method_name="save_checkpoint",
                 tag=tag,
@@ -521,7 +633,16 @@ class BaseRLTrainer:
                     method_name="save_checkpoint", tag=tag, metric_value=current_value, metric_key=metric_key
                 )
             ray.get(refs)
-            logger.info(f"Saved best checkpoint: {tag} ({metric_key}={current_value:.4f})")
+
+        self._prune_hf_checkpoints()
+        prev_best = self.best_eval_metric_value
+        self.best_eval_metric_key = metric_key
+        self.best_eval_metric_value = current_value
+        logger.info(
+            f"New best eval metric: {metric_key}={current_value:.4f} at step {global_step} "
+            f"(previous best: {prev_best if prev_best > float('-inf') else 'N/A'})"
+        )
+        logger.info(f"Saved best checkpoint: {tag} ({metric_key}={current_value:.4f})")
 
     def save_logs_and_checkpoints(self, global_step: int, logs_dict=None, client_states=None) -> None:
         logs_dict = logs_dict or {}
@@ -541,7 +662,10 @@ class BaseRLTrainer:
             # rotated out by max_num cleanup).
             client_states["best_eval_metric_key"] = self.best_eval_metric_key
             client_states["best_eval_metric_value"] = self.best_eval_metric_value
-            metric_value = self._latest_eval_metric_value
+            # Retention sorts rolling checkpoints by metric before age. Use the
+            # monotonic best-so-far value so older checkpoints never outrank a
+            # recent source that an in-flight async evaluation may still need.
+            metric_value = None if self.best_eval_metric_value == float("-inf") else self.best_eval_metric_value
             metric_key = client_states.get("checkpoint_metric_key") or self.best_eval_metric_key or None
             refs = self.actor_model_group.async_run_method(
                 method_name="save_checkpoint",
@@ -555,6 +679,7 @@ class BaseRLTrainer:
                     method_name="save_checkpoint", tag=tag, metric_value=metric_value, metric_key=metric_key
                 )
             ray.get(refs)
+            self._prune_hf_checkpoints()
 
     def load_checkpoint_states_or_default(self) -> Dict:
         ckpt_path = os.path.join(self.args.ckpt.path, "_actor")
@@ -579,15 +704,19 @@ class BaseRLTrainer:
 
 @ray.remote(num_cpus=0)
 class VLLMLock:
-    """Cross-actor mutex for vLLM critical sections."""
+    """Cross-actor mutex carrying the policy version currently loaded by vLLM."""
 
     def __init__(self):
         self._lock = asyncio.Lock()
+        self._policy_step = 0
 
     async def acquire(self):
         await self._lock.acquire()
+        return self._policy_step
 
-    async def release(self):
+    async def release(self, policy_step=None):
+        if policy_step is not None:
+            self._policy_step = policy_step
         self._lock.release()
 
 
@@ -726,22 +855,23 @@ class GenerateSamplesActor:
                 if should_eval:
                     self._last_eval_step = global_step
                     self._next_eval_step = (global_step // eval_steps + 1) * eval_steps
-                    logger.info(f"Starting async evaluation at step {global_step}...")
                     # Under partial rollout the rollout path (below) deliberately
                     # skips vllm_lock so the trainer's broadcast_to_vllm refit can
                     # interleave via pause/resume. Eval must follow the same
                     # contract: holding the lock across the whole eval generation
                     # (~1hr at 32K) blocks the refit's acquire and wedges training
                     # (train_step never returns → no global_step advance).
+                    policy_step = global_step
                     if not self._partial_rollout:
-                        ray.get(self.vllm_lock.acquire.remote())
+                        policy_step = ray.get(self.vllm_lock.acquire.remote())
+                    logger.info(f"Starting async evaluation of vLLM policy step {policy_step}...")
                     try:
                         eval_metrics = self._run_eval()
                     finally:
                         if not self._partial_rollout:
                             ray.get(self.vllm_lock.release.remote())
                     logger.info(f"Async evaluation completed: {eval_metrics}")
-                    self.rollout_queue.put(("eval", global_step, eval_metrics), block=True)
+                    self.rollout_queue.put(("eval", policy_step, eval_metrics), block=True)
                     continue
 
                 if self.args.train.rollout_replay_dir:
@@ -877,7 +1007,8 @@ class TrainingActor(BaseRLTrainer):
                     self.tensorboard_logger.log_eval(eval_step, eval_metrics)
                 client_states = dict(self._latest_client_states)
                 client_states["global_step"] = global_step
-                self.save_best_checkpoint(eval_metrics, eval_step, client_states)
+                source_tag = None if eval_step == global_step else f"global_step{eval_step}"
+                self.save_best_checkpoint(eval_metrics, eval_step, client_states, source_tag=source_tag)
                 step_start_time = time.time()
                 continue
 
@@ -923,7 +1054,7 @@ class TrainingActor(BaseRLTrainer):
         if self.tensorboard_logger:
             self.tensorboard_logger.close()
 
-    def broadcast_to_vllm(self):
+    def broadcast_to_vllm(self, policy_step=None, refit=True):
         # Keep new generation calls out while existing requests are paused and
         # refitted. Report lock wait separately from the weight transfer. The lock
         # release sits in finally so a failed refit (NCCL errors do happen mid-run)
@@ -933,14 +1064,17 @@ class TrainingActor(BaseRLTrainer):
         ray.get(self.vllm_lock.acquire.remote())
         self._broadcast_lock_wait_s = time.time() - _t0
         _t0 = time.time()
+        synced_policy_step = None
         try:
-            batch_vllm_engine_call(self.vllm_engines, "pause_generation")
-            super().broadcast_to_vllm()
-            if self._prefix_caching_enabled:
-                batch_vllm_engine_call(self.vllm_engines, "reset_prefix_cache")
-            batch_vllm_engine_call(self.vllm_engines, "resume_generation")
+            if refit:
+                batch_vllm_engine_call(self.vllm_engines, "pause_generation")
+                super().broadcast_to_vllm()
+                if self._prefix_caching_enabled:
+                    batch_vllm_engine_call(self.vllm_engines, "reset_prefix_cache")
+                batch_vllm_engine_call(self.vllm_engines, "resume_generation")
+            synced_policy_step = policy_step
         finally:
-            ray.get(self.vllm_lock.release.remote())
+            ray.get(self.vllm_lock.release.remote(synced_policy_step))
             self._broadcast_transfer_s = time.time() - _t0
 
 
@@ -967,6 +1101,34 @@ class RLTrainer:
         queue_size = getattr(strategy.args.train, "async_queue_size", 1)
         if queue_size <= 0:
             raise ValueError(f"async_queue_size must be positive, got {queue_size}")
+
+        best_selection_enabled = (
+            getattr(strategy.args.eval, "dataset", None)
+            and strategy.args.eval.steps != float("inf")
+            and getattr(strategy.args.ckpt, "best_metric_key", "") != "none"
+            and not getattr(strategy.args.train, "partial_rollout_enable", False)
+        )
+        force_sync = getattr(strategy.args.train, "force_sync_mode", False)
+        delayed_best_possible = best_selection_enabled and (not force_sync or queue_size > 1)
+        if delayed_best_possible and strategy.args.ckpt.save_steps != 1:
+            raise ValueError(
+                "Delayed best-checkpoint selection requires --ckpt.save_steps 1, so either policy that can win "
+                "the generation/refit race has a matching resumable checkpoint."
+            )
+        if delayed_best_possible:
+            max_num = getattr(strategy.args.ckpt, "max_num", 3)
+            min_num = queue_size + 1
+            if max_num > 0 and max_num < min_num:
+                raise ValueError(
+                    "Delayed best-checkpoint selection requires --ckpt.max_num at least "
+                    f"async_queue_size + 1 ({min_num}), or a non-positive value to disable count-based pruning."
+                )
+            max_mem = getattr(strategy.args.ckpt, "max_mem", float("inf"))
+            if 0 < max_mem < float("inf"):
+                raise ValueError(
+                    "Delayed best-checkpoint selection requires unbounded --ckpt.max_mem; a disk cap can evict "
+                    "the checkpoint of an in-flight evaluation before its metric arrives."
+                )
         logger.info(f"async_queue_size={queue_size}")
 
         self.rollout_queue = Queue(maxsize=queue_size)
@@ -1021,7 +1183,7 @@ class RLTrainer:
                         checkpoint_states["data_loader_state_dict"],
                         checkpoint_states.get("rollout_generator_state_dict"),
                     ),
-                    self.trainer_actor.broadcast_to_vllm.remote(),
+                    self.trainer_actor.broadcast_to_vllm.remote(global_step),
                 ]
             )
 

--- a/molt/trainer/rl_trainer.py
+++ b/molt/trainer/rl_trainer.py
@@ -336,7 +336,8 @@ class BaseRLTrainer:
             return
 
         actor_root = os.path.join(self.args.ckpt.path, "_actor")
-        if not os.path.isdir(actor_root):
+        hf_root = os.path.join(self.args.ckpt.path, "_hf")
+        if not os.path.isdir(actor_root) or not os.path.isdir(hf_root):
             return
         retained_tags = {
             name
@@ -344,12 +345,9 @@ class BaseRLTrainer:
             if (name.startswith("global_step") or name.startswith("best_global_step"))
             and self.strategy.checkpoint._is_loadable_ckpt_dir(os.path.join(actor_root, name))
         }
-        for name in os.listdir(self.args.ckpt.path):
-            if not name.endswith("_hf"):
-                continue
-            tag = name[:-3]
+        for tag in os.listdir(hf_root):
             if (tag.startswith("global_step") or tag.startswith("best_global_step")) and tag not in retained_tags:
-                shutil.rmtree(os.path.join(self.args.ckpt.path, name), ignore_errors=True)
+                shutil.rmtree(os.path.join(hf_root, tag), ignore_errors=True)
 
     def fit(self, global_step: int = 0) -> None:
         raise NotImplementedError("fit method is not implemented")
@@ -554,10 +552,11 @@ class BaseRLTrainer:
                 checkpoint_roots.append(os.path.join(self.args.ckpt.path, "_critic"))
             copies = [(os.path.join(root, source_tag), os.path.join(root, tag), root) for root in checkpoint_roots]
             if self.args.ckpt.save_hf:
+                hf_root = os.path.join(self.args.ckpt.path, "_hf")
                 copies.append(
                     (
-                        os.path.join(self.args.ckpt.path, f"{source_tag}_hf"),
-                        os.path.join(self.args.ckpt.path, f"{tag}_hf"),
+                        os.path.join(hf_root, source_tag),
+                        os.path.join(hf_root, tag),
                         None,
                     )
                 )
@@ -1116,11 +1115,19 @@ class RLTrainer:
                 "the generation/refit race has a matching resumable checkpoint."
             )
         if delayed_best_possible:
-            max_num = getattr(strategy.args.ckpt, "max_num", 3)
             min_num = queue_size + 1
-            if max_num > 0 and max_num < min_num:
+            max_num = getattr(strategy.args.ckpt, "max_num", 3)
+            dcp_max_num = getattr(strategy.args.ckpt, "dcp_max_num", None)
+            if dcp_max_num is None:
+                dcp_max_num = max_num
+            if dcp_max_num > 0 and dcp_max_num < min_num:
                 raise ValueError(
-                    "Delayed best-checkpoint selection requires --ckpt.max_num at least "
+                    "Delayed best-checkpoint selection requires --ckpt.dcp_max_num at least "
+                    f"async_queue_size + 1 ({min_num}), or a non-positive value to disable count-based pruning."
+                )
+            if getattr(strategy.args.ckpt, "save_hf", False) and 0 < max_num < min_num:
+                raise ValueError(
+                    "Delayed best-checkpoint selection with --ckpt.save_hf requires --ckpt.max_num at least "
                     f"async_queue_size + 1 ({min_num}), or a non-positive value to disable count-based pruning."
                 )
             max_mem = getattr(strategy.args.ckpt, "max_mem", float("inf"))

--- a/molt/trainer/rl_trainer.py
+++ b/molt/trainer/rl_trainer.py
@@ -1112,7 +1112,7 @@ class RLTrainer:
         delayed_best_possible = best_selection_enabled and (not force_sync or queue_size > 1)
         if delayed_best_possible and strategy.args.ckpt.save_steps != 1:
             raise ValueError(
-                "Delayed best-checkpoint selection requires --ckpt.save_steps 1, so either policy that can win "
+                "Delayed best-checkpoint selection requires --ckpt.save_steps 1, so every policy that can win "
                 "the generation/refit race has a matching resumable checkpoint."
             )
         if delayed_best_possible:

--- a/tests/unit/test_rl_trainer.py
+++ b/tests/unit/test_rl_trainer.py
@@ -109,10 +109,11 @@ def _transaction_tree(tmp_path, previous_step):
             f"old-{role}",
         )
         sources[role] = source
-    sources["hf"] = tmp_path / f"{source_tag}_hf"
-    sources["hf"].mkdir()
+    hf_root = tmp_path / "_hf"
+    sources["hf"] = hf_root / source_tag
+    sources["hf"].mkdir(parents=True)
     (sources["hf"] / "model.safetensors").write_text("new-hf")
-    previous_hf = tmp_path / f"best_global_step{previous_step}_hf"
+    previous_hf = hf_root / f"best_global_step{previous_step}"
     previous_hf.mkdir()
     (previous_hf / "model.safetensors").write_text("old-hf")
     return source_tag, sources, previous_hf
@@ -128,8 +129,12 @@ def _controller_strategy(
     force_sync=False,
     queue_size=1,
     max_num=3,
+    dcp_max_num=None,
     max_mem=float("inf"),
+    save_hf=False,
 ):
+    if dcp_max_num is None:
+        dcp_max_num = max_num
     return SimpleNamespace(
         args=SimpleNamespace(
             eval=SimpleNamespace(dataset=eval_dataset, steps=eval_steps),
@@ -137,7 +142,9 @@ def _controller_strategy(
                 save_steps=save_steps,
                 best_metric_key=best_metric_key,
                 max_num=max_num,
+                dcp_max_num=dcp_max_num,
                 max_mem=max_mem,
+                save_hf=save_hf,
             ),
             train=SimpleNamespace(
                 partial_rollout_enable=partial,
@@ -345,7 +352,7 @@ def test_delayed_best_copies_actor_critic_and_hf_from_the_eval_step(tmp_path):
         assert not (tmp_path / f"_{role}" / "best_global_step1").exists()
         assert (sources[role] / "model" / "shard").exists()
 
-    assert (tmp_path / "best_global_step5_hf" / "model.safetensors").read_text() == "new-hf"
+    assert (tmp_path / "_hf" / "best_global_step5" / "model.safetensors").read_text() == "new-hf"
     assert (sources["hf"] / "model.safetensors").exists()
     assert not old_hf.exists()
     assert not [path for path in tmp_path.rglob("*") if path.name.endswith((".tmp", ".old"))]
@@ -374,7 +381,7 @@ def test_delayed_best_copy_failure_leaves_no_partial_promotion(monkeypatch, tmp_
     assert all((tmp_path / f"_{role}" / "best_global_step1").exists() for role in ("actor", "critic"))
     assert old_hf.exists()
     assert not list(tmp_path.rglob("best_global_step5"))
-    assert not (tmp_path / "best_global_step5_hf").exists()
+    assert not (tmp_path / "_hf" / "best_global_step5").exists()
     assert not [path for path in tmp_path.rglob("*") if path.name.endswith((".tmp", ".old"))]
     assert trainer.best_eval_metric_key == ""
     assert trainer.best_eval_metric_value == float("-inf")
@@ -411,7 +418,7 @@ def test_delayed_best_publish_failure_rolls_back_every_role(monkeypatch, tmp_pat
     pending = {
         "actor": tmp_path / "_actor" / "best_global_step5.tmp",
         "critic": tmp_path / "_critic" / "best_global_step5.tmp",
-        "hf": tmp_path / "best_global_step5_hf.tmp",
+        "hf": tmp_path / "_hf" / "best_global_step5.tmp",
     }
 
     def fail_publish(source, destination):
@@ -471,8 +478,8 @@ def test_restore_prefers_durable_best_metadata_over_stale_latest(tmp_path):
     )
     trainer = _trainer(tmp_path, _ActorGroup({"step": 6}), load=True)
     trainer.args.ckpt.save_hf = True
-    orphan_hf = tmp_path / "best_global_step1_hf"
-    orphan_hf.mkdir()
+    orphan_hf = tmp_path / "_hf" / "best_global_step1"
+    orphan_hf.mkdir(parents=True)
     (orphan_hf / "model.safetensors").write_text("orphan")
     for suffix in (".tmp", ".old"):
         pending = tmp_path / "_actor" / f"best_global_step9{suffix}"
@@ -507,15 +514,16 @@ def test_fresh_run_ignores_best_metadata_left_in_output_directory(tmp_path):
 
 
 def test_hf_exports_follow_retained_actor_checkpoints(tmp_path):
+    hf_root = tmp_path / "_hf"
     retained = {"global_step2", "global_step3", "best_global_step2"}
     for tag in retained:
         checkpoint = tmp_path / "_actor" / tag
         _write_checkpoint(checkpoint)
-        export = tmp_path / f"{tag}_hf"
-        export.mkdir()
+        export = hf_root / tag
+        export.mkdir(parents=True)
         (export / "model.safetensors").write_text(tag)
     for tag in ("global_step1", "best_global_step1"):
-        export = tmp_path / f"{tag}_hf"
+        export = hf_root / tag
         export.mkdir()
         (export / "model.safetensors").write_text(tag)
 
@@ -523,7 +531,7 @@ def test_hf_exports_follow_retained_actor_checkpoints(tmp_path):
     trainer.args.ckpt.save_hf = True
     trainer._prune_hf_checkpoints()
 
-    assert {path.name for path in tmp_path.glob("*_hf")} == {f"{tag}_hf" for tag in retained}
+    assert {path.name for path in hf_root.iterdir()} == retained
 
 
 def test_rolling_retention_uses_monotonic_best_metric(monkeypatch, tmp_path):
@@ -543,6 +551,10 @@ def test_rolling_retention_uses_monotonic_best_metric(monkeypatch, tmp_path):
     "config",
     [
         pytest.param({"queue_size": 2}, id="async-best"),
+        pytest.param(
+            {"queue_size": 2, "dcp_max_num": 3, "max_num": 1},
+            id="dcp-retention-decoupled-from-hf",
+        ),
         pytest.param({"save_steps": -1, "force_sync": True}, id="force-sync"),
         pytest.param({"save_steps": 5, "partial": True, "max_num": 1, "max_mem": 100}, id="partial"),
         pytest.param({"eval_steps": 25, "save_steps": 1000, "best_metric_key": "none"}, id="best-disabled"),
@@ -580,7 +592,11 @@ def test_async_best_requires_a_rolling_checkpoint_for_every_policy_step(config):
 @pytest.mark.parametrize(
     ("config", "message"),
     [
-        ({"queue_size": 2, "max_num": 2}, "max_num"),
+        ({"queue_size": 2, "dcp_max_num": 2}, "dcp_max_num"),
+        (
+            {"queue_size": 2, "dcp_max_num": 3, "max_num": 2, "save_hf": True},
+            "--ckpt.max_num",
+        ),
         ({"queue_size": 2, "max_mem": 100}, "max_mem"),
     ],
 )

--- a/tests/unit/test_rl_trainer.py
+++ b/tests/unit/test_rl_trainer.py
@@ -1,0 +1,592 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+import errno
+import os
+from collections import deque
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+
+import molt.trainer.rl_trainer as rl_trainer
+from molt.trainer.fsdp.checkpoint import CheckpointManager
+
+
+class _Queue:
+    def __init__(self, values=()):
+        self.values = deque(values)
+        self.put_values = []
+
+    def get(self, block=True):
+        return self.values.popleft()
+
+    def put(self, value, block=True):
+        self.put_values.append(value)
+
+
+class _RemoteMethod:
+    def __init__(self, fn):
+        self.fn = fn
+
+    def remote(self, *args, **kwargs):
+        return self.fn(*args, **kwargs)
+
+
+class _VLLMLock:
+    def __init__(self, policy_step):
+        self.policy_step = policy_step
+        self.acquire_calls = 0
+        self.release_calls = 0
+        self.acquire = _RemoteMethod(self._acquire)
+        self.release = _RemoteMethod(self._release)
+
+    def _acquire(self):
+        self.acquire_calls += 1
+        return self.policy_step()
+
+    def _release(self, policy_step=None):
+        self.release_calls += 1
+        if policy_step is not None:
+            self.policy_step = lambda: policy_step
+
+
+class _ActorGroup:
+    def __init__(self, policy_state):
+        self.policy_state = policy_state
+        self.checkpoints = {}
+        self.save_calls = []
+
+    def async_run_method(self, method_name, **kwargs):
+        if method_name == "save_checkpoint":
+            self.save_calls.append(kwargs)
+            client_step = (kwargs.get("client_states") or {}).get("global_step")
+            self.checkpoints[kwargs["tag"]] = (self.policy_state["step"], client_step)
+        return []
+
+
+class _Strategy:
+    def __init__(self):
+        self.checkpoint = CheckpointManager(self)
+
+    def print(self, *_args):
+        pass
+
+
+def _write_checkpoint(path, client_state=None, model=None, optimizer=None):
+    (path / "model").mkdir(parents=True)
+    if model is not None:
+        (path / "model" / "shard").write_text(model)
+    if optimizer is not None:
+        (path / "optimizer").mkdir()
+        (path / "optimizer" / "shard").write_text(optimizer)
+    torch.save({"client_state": client_state or {}}, path / "extra_state.pt")
+
+
+def _transaction_tree(tmp_path, previous_step):
+    source_tag = "global_step5"
+    sources = {}
+    for role in ("actor", "critic"):
+        source = tmp_path / f"_{role}" / source_tag
+        _write_checkpoint(source, {"global_step": 5}, f"new-{role}", f"{role}-optimizer-step5")
+        _write_checkpoint(
+            tmp_path / f"_{role}" / f"best_global_step{previous_step}",
+            {"global_step": previous_step},
+            f"old-{role}",
+        )
+        sources[role] = source
+    sources["hf"] = tmp_path / f"{source_tag}_hf"
+    sources["hf"].mkdir()
+    (sources["hf"] / "model.safetensors").write_text("new-hf")
+    previous_hf = tmp_path / f"best_global_step{previous_step}_hf"
+    previous_hf.mkdir()
+    (previous_hf / "model.safetensors").write_text("old-hf")
+    return source_tag, sources, previous_hf
+
+
+def _controller_strategy(
+    *,
+    eval_dataset="eval.jsonl",
+    eval_steps=5,
+    save_steps=1,
+    best_metric_key="",
+    partial=False,
+    force_sync=False,
+    queue_size=1,
+    max_num=3,
+    max_mem=float("inf"),
+):
+    return SimpleNamespace(
+        args=SimpleNamespace(
+            eval=SimpleNamespace(dataset=eval_dataset, steps=eval_steps),
+            ckpt=SimpleNamespace(
+                save_steps=save_steps,
+                best_metric_key=best_metric_key,
+                max_num=max_num,
+                max_mem=max_mem,
+            ),
+            train=SimpleNamespace(
+                partial_rollout_enable=partial,
+                force_sync_mode=force_sync,
+                async_queue_size=queue_size,
+            ),
+        )
+    )
+
+
+def _trainer(tmp_path, actor_group, critic_group=None, *, force_sync=False, partial=False, load=False, queue=()):
+    trainer_cls = rl_trainer.TrainingActor.__ray_metadata__.modified_class
+    trainer = trainer_cls.__new__(trainer_cls)
+    trainer.args = SimpleNamespace(
+        train=SimpleNamespace(force_sync_mode=force_sync, partial_rollout_enable=partial),
+        eval=SimpleNamespace(dataset="eval.jsonl", steps=5, eval_at_start=False),
+        ckpt=SimpleNamespace(path=str(tmp_path), save_hf=False, load_enable=load),
+    )
+    trainer.strategy = _Strategy()
+    trainer.actor_model_group = actor_group
+    trainer.critic_model_group = critic_group
+    trainer.vllm_lock = _VLLMLock(lambda: actor_group.policy_state["step"])
+    trainer.rollout_queue = _Queue(queue)
+    trainer.rollout_slots = _Queue()
+    trainer.wandb_logger = None
+    trainer.tensorboard_logger = None
+    trainer.best_eval_metric_value = float("-inf")
+    trainer.best_eval_metric_key = "eval_pass1"
+    return trainer
+
+
+def test_eval_uses_vllm_version_when_broadcast_wins_slot_race(monkeypatch, tmp_path):
+    dataloader = MagicMock()
+    dataloader.__len__.return_value = 1
+    dataloader.sampler = None
+    dataloader.state_dict.return_value = {}
+    samples_generator = MagicMock()
+    samples_generator.generate_eval_samples.return_value = ["sample"]
+    monkeypatch.setattr(rl_trainer.ray, "get", lambda refs: refs)
+    monkeypatch.setattr(rl_trainer, "tqdm", lambda *_args, **_kwargs: MagicMock())
+    monkeypatch.setattr(rl_trainer, "compute_eval_metrics", lambda *_args: {"eval_pass1": 1.0})
+
+    generator_cls = rl_trainer.GenerateSamplesActor.__ray_metadata__.modified_class
+    generator = generator_cls.__new__(generator_cls)
+    generator.args = SimpleNamespace(
+        train=SimpleNamespace(num_episodes=1, rollout_replay_dir=str(tmp_path), rollout_dump_dir=None),
+        eval=SimpleNamespace(
+            steps=5,
+            eval_at_start=False,
+            n_samples_per_prompt=None,
+            temperature=None,
+            top_p=None,
+            max_new_tokens=None,
+        ),
+        rollout=SimpleNamespace(n_samples_per_prompt=1),
+    )
+    generator.prompts_dataloader = dataloader
+    generator.eval_dataloader = object()
+    generator.samples_generator = samples_generator
+    generator.generate_kwargs = {}
+    generator.vllm_lock = _VLLMLock(lambda: 6)
+    generator._partial_rollout = False
+    generator.rollout_queue = _Queue()
+    generator.rollout_slots = _Queue([5, 6])
+    generator._last_eval_step = -1
+    generator._next_eval_step = 5
+    generator._eval_at_start = False
+
+    generator.fit(episode=0, total_consumed_prompts=0)
+
+    assert generator.rollout_queue.put_values[0] == ("eval", 6, {"eval_pass1": 1.0})
+    assert generator.vllm_lock.acquire_calls == 1
+    assert generator.vllm_lock.release_calls == 1
+
+
+def test_vllm_lock_returns_the_version_published_by_the_broadcast_that_won_the_race():
+    lock_cls = rl_trainer.VLLMLock.__ray_metadata__.modified_class
+
+    async def run_race():
+        lock = lock_cls()
+        assert await lock.acquire() == 0
+        waiting_eval = asyncio.create_task(lock.acquire())
+        await asyncio.sleep(0)
+        await lock.release(policy_step=6)
+        assert await waiting_eval == 6
+        await lock.release()
+
+    asyncio.run(run_race())
+
+
+@pytest.mark.parametrize(
+    ("force_sync", "event_order"),
+    [
+        (False, ("rollout-step4", "rollout-step5", "eval-step5")),
+        (True, ("rollout-step4", "eval-step5", "rollout-step5")),
+        (
+            False,
+            (
+                "rollout-step4",
+                "rollout-step5",
+                "rollout-step6",
+                "rollout-step7",
+                "rollout-step8",
+                "rollout-step9",
+                "rollout-step10",
+                "eval-step5",
+                "eval-step10",
+            ),
+        ),
+    ],
+)
+def test_async_eval_saves_the_policy_that_produced_the_metric(monkeypatch, tmp_path, force_sync, event_order):
+    """A delayed step-5 metric must keep step-5 actor and client state."""
+    monkeypatch.setattr(rl_trainer.ray, "get", lambda refs: refs)
+
+    policy_state = {"step": 4}
+    actor_group = _ActorGroup(policy_state)
+    critic_group = _ActorGroup(policy_state)
+    events = {
+        **{f"rollout-step{step}": (f"rollout-step{step}", {"episode": 0}, {}, 0.0, 0.0) for step in range(4, 11)},
+        "eval-step5": ("eval", 5, {"eval_pass1": 1.0}),
+        "eval-step10": ("eval", 10, {"eval_pass1": 0.5}),
+    }
+
+    trainer = _trainer(
+        tmp_path,
+        actor_group,
+        critic_group,
+        force_sync=force_sync,
+        queue=[events[name] for name in event_order] + ["done"],
+    )
+
+    def train_step(_rollout_samples, global_step):
+        policy_state["step"] += 1
+        return {}, global_step + 1
+
+    def save_checkpoint(global_step, *_args, **_kwargs):
+        if global_step % 5:
+            return
+        for role in ("_actor", "_critic"):
+            saved = tmp_path / role / f"global_step{global_step}"
+            (saved / "model").mkdir(parents=True)
+            (saved / "optimizer").mkdir()
+            (saved / "model" / "policy_step").write_text(str(policy_state["step"]))
+            (saved / "optimizer" / "state").write_text(f"optimizer-step{global_step}")
+            torch.save({"client_state": {"global_step": global_step}}, saved / "extra_state.pt")
+
+    trainer.train_step = train_step
+    trainer.save_logs_and_checkpoints = save_checkpoint
+
+    trainer.fit(global_step=4)
+
+    if force_sync:
+        assert actor_group.checkpoints["best_global_step5"] == (5, 5)
+        assert critic_group.checkpoints["best_global_step5"] == (5, None)
+    else:
+        for role in ("_actor", "_critic"):
+            best = tmp_path / role / "best_global_step5"
+            assert (best / "model" / "policy_step").read_text() == "5"
+            assert (best / "optimizer" / "state").read_text() == "optimizer-step5"
+            state = torch.load(best / "extra_state.pt", weights_only=False)["client_state"]
+            assert state["global_step"] == 5
+
+
+def test_partial_rollout_does_not_select_a_best_checkpoint(monkeypatch, tmp_path):
+    monkeypatch.setattr(rl_trainer.ray, "get", lambda refs: refs)
+    warning = MagicMock()
+    monkeypatch.setattr(rl_trainer.logger, "warning", warning)
+
+    policy_state = {"step": 5}
+    actor_group = _ActorGroup(policy_state)
+    trainer = _trainer(
+        tmp_path,
+        actor_group,
+        partial=True,
+        queue=[("eval", 5, {"eval_pass1": 1.0}), "done"],
+    )
+
+    trainer.fit(global_step=5)
+
+    assert actor_group.checkpoints == {}
+    assert trainer.best_eval_metric_value == float("-inf")
+    assert "one evaluation can span multiple policy versions" in warning.call_args.args[0]
+
+
+def test_delayed_best_copies_actor_critic_and_hf_from_the_eval_step(tmp_path):
+    source_tag, sources, old_hf = _transaction_tree(tmp_path, previous_step=1)
+
+    trainer = _trainer(tmp_path, object(), object())
+    trainer.args.ckpt.save_hf = True
+
+    trainer.save_best_checkpoint(
+        {"eval_pass1": 0.75},
+        5,
+        source_tag=source_tag,
+    )
+
+    for role in ("actor", "critic"):
+        promoted = tmp_path / f"_{role}" / "best_global_step5"
+        assert (promoted / "model" / "shard").read_text() == f"new-{role}"
+        assert (promoted / "optimizer" / "shard").read_text() == f"{role}-optimizer-step5"
+        state = torch.load(promoted / "extra_state.pt", weights_only=False)["client_state"]
+        assert state["global_step"] == 5
+        assert state["best_eval_metric_value"] == 0.75
+        assert not (tmp_path / f"_{role}" / "best_global_step1").exists()
+        assert (sources[role] / "model" / "shard").exists()
+
+    assert (tmp_path / "best_global_step5_hf" / "model.safetensors").read_text() == "new-hf"
+    assert (sources["hf"] / "model.safetensors").exists()
+    assert not old_hf.exists()
+    assert not [path for path in tmp_path.rglob("*") if path.name.endswith((".tmp", ".old"))]
+
+
+@pytest.mark.parametrize("failed_role", ["actor", "critic", "hf"])
+def test_delayed_best_copy_failure_leaves_no_partial_promotion(monkeypatch, tmp_path, failed_role):
+    source_tag, sources, old_hf = _transaction_tree(tmp_path, previous_step=1)
+
+    copytree = rl_trainer.shutil.copytree
+
+    def fail_copy(source, destination, *args, **kwargs):
+        if os.fspath(source) == str(sources[failed_role]):
+            os.makedirs(destination)
+            raise OSError(errno.ENOSPC, "injected copy failure")
+        return copytree(source, destination, *args, **kwargs)
+
+    monkeypatch.setattr(rl_trainer.shutil, "copytree", fail_copy)
+    trainer = _trainer(tmp_path, object(), object())
+    trainer.args.ckpt.save_hf = True
+    trainer.best_eval_metric_key = ""
+
+    with pytest.raises(OSError, match="injected copy failure"):
+        trainer.save_best_checkpoint({"eval_pass1": 0.75}, 5, source_tag=source_tag)
+
+    assert all((tmp_path / f"_{role}" / "best_global_step1").exists() for role in ("actor", "critic"))
+    assert old_hf.exists()
+    assert not list(tmp_path.rglob("best_global_step5"))
+    assert not (tmp_path / "best_global_step5_hf").exists()
+    assert not [path for path in tmp_path.rglob("*") if path.name.endswith((".tmp", ".old"))]
+    assert trainer.best_eval_metric_key == ""
+    assert trainer.best_eval_metric_value == float("-inf")
+
+
+def test_delayed_best_recovers_an_orphaned_backup_before_copying(monkeypatch, tmp_path):
+    source = tmp_path / "_actor" / "global_step5"
+    backup = tmp_path / "_actor" / "best_global_step5.old"
+    _write_checkpoint(source, {"global_step": 5}, "new-actor")
+    _write_checkpoint(backup, {"global_step": 5}, "old-actor")
+
+    def fail_copy(_source, destination):
+        os.makedirs(destination)
+        raise OSError(errno.ENOSPC, "injected copy failure")
+
+    monkeypatch.setattr(rl_trainer.shutil, "copytree", fail_copy)
+    trainer = _trainer(tmp_path, object())
+
+    with pytest.raises(OSError, match="injected copy failure"):
+        trainer.save_best_checkpoint({"eval_pass1": 0.75}, 5, source_tag="global_step5")
+
+    best = tmp_path / "_actor" / "best_global_step5"
+    assert (best / "model" / "shard").read_text() == "old-actor"
+    assert not backup.exists()
+    assert not (tmp_path / "_actor" / "best_global_step5.tmp").exists()
+    assert trainer.best_eval_metric_value == float("-inf")
+
+
+@pytest.mark.parametrize("failed_role", ["actor", "critic", "hf"])
+def test_delayed_best_publish_failure_rolls_back_every_role(monkeypatch, tmp_path, failed_role):
+    source_tag, _, previous_hf = _transaction_tree(tmp_path, previous_step=5)
+
+    replace = rl_trainer.os.replace
+    pending = {
+        "actor": tmp_path / "_actor" / "best_global_step5.tmp",
+        "critic": tmp_path / "_critic" / "best_global_step5.tmp",
+        "hf": tmp_path / "best_global_step5_hf.tmp",
+    }
+
+    def fail_publish(source, destination):
+        if source == str(pending[failed_role]):
+            raise OSError("injected publish failure")
+        return replace(source, destination)
+
+    monkeypatch.setattr(rl_trainer.os, "replace", fail_publish)
+    trainer = _trainer(tmp_path, object(), object())
+    trainer.args.ckpt.save_hf = True
+    trainer.best_eval_metric_key = ""
+
+    with pytest.raises(OSError, match="injected publish failure"):
+        trainer.save_best_checkpoint({"eval_pass1": 0.75}, 5, source_tag=source_tag)
+
+    for role in ("actor", "critic"):
+        assert (tmp_path / f"_{role}" / "best_global_step5" / "model" / "shard").read_text() == f"old-{role}"
+    assert (previous_hf / "model.safetensors").read_text() == "old-hf"
+    assert not [path for path in tmp_path.rglob("*") if path.name.endswith((".tmp", ".old"))]
+    assert trainer.best_eval_metric_key == ""
+    assert trainer.best_eval_metric_value == float("-inf")
+
+
+def test_nan_eval_metric_is_not_promoted(tmp_path):
+    actor_group = _ActorGroup({"step": 5})
+    trainer = _trainer(tmp_path, actor_group)
+
+    trainer.save_best_checkpoint({"eval_pass1": float("nan")}, 5)
+
+    assert actor_group.checkpoints == {}
+    assert trainer.best_eval_metric_value == float("-inf")
+
+
+def test_delayed_best_is_skipped_when_the_eval_step_was_not_saved(monkeypatch, tmp_path):
+    warning = MagicMock()
+    monkeypatch.setattr(rl_trainer.logger, "warning", warning)
+    actor_group = _ActorGroup({"step": 6})
+    trainer = _trainer(tmp_path, actor_group)
+    trainer.best_eval_metric_key = ""
+
+    trainer.save_best_checkpoint({"eval_pass1": 1.0}, 5, source_tag="global_step5")
+
+    assert actor_group.checkpoints == {}
+    assert trainer.best_eval_metric_key == ""
+    assert trainer.best_eval_metric_value == float("-inf")
+    assert "matching saved checkpoint global_step5 is unavailable" in warning.call_args.args[0]
+
+
+def test_restore_prefers_durable_best_metadata_over_stale_latest(tmp_path):
+    best = tmp_path / "_actor" / "best_global_step5"
+    _write_checkpoint(
+        best,
+        {
+            "best_eval_metric_key": "eval_pass1",
+            "best_eval_metric_value": 0.75,
+        },
+    )
+    trainer = _trainer(tmp_path, _ActorGroup({"step": 6}), load=True)
+    trainer.args.ckpt.save_hf = True
+    orphan_hf = tmp_path / "best_global_step1_hf"
+    orphan_hf.mkdir()
+    (orphan_hf / "model.safetensors").write_text("orphan")
+    for suffix in (".tmp", ".old"):
+        pending = tmp_path / "_actor" / f"best_global_step9{suffix}"
+        _write_checkpoint(pending, {"best_eval_metric_key": "wrong", "best_eval_metric_value": 1.0})
+
+    trainer.restore_best_metric_tracker(
+        {
+            "best_eval_metric_key": "eval_pass1",
+            "best_eval_metric_value": 0.5,
+        }
+    )
+
+    assert trainer.best_eval_metric_key == "eval_pass1"
+    assert trainer.best_eval_metric_value == 0.75
+    assert not orphan_hf.exists()
+
+
+def test_fresh_run_ignores_best_metadata_left_in_output_directory(tmp_path):
+    best = tmp_path / "_actor" / "best_global_step5"
+    _write_checkpoint(
+        best,
+        {
+            "best_eval_metric_key": "eval_pass1",
+            "best_eval_metric_value": 0.75,
+        },
+    )
+    trainer = _trainer(tmp_path, _ActorGroup({"step": 0}), load=False)
+
+    trainer.restore_best_metric_tracker({})
+
+    assert trainer.best_eval_metric_value == float("-inf")
+
+
+def test_hf_exports_follow_retained_actor_checkpoints(tmp_path):
+    retained = {"global_step2", "global_step3", "best_global_step2"}
+    for tag in retained:
+        checkpoint = tmp_path / "_actor" / tag
+        _write_checkpoint(checkpoint)
+        export = tmp_path / f"{tag}_hf"
+        export.mkdir()
+        (export / "model.safetensors").write_text(tag)
+    for tag in ("global_step1", "best_global_step1"):
+        export = tmp_path / f"{tag}_hf"
+        export.mkdir()
+        (export / "model.safetensors").write_text(tag)
+
+    trainer = _trainer(tmp_path, _ActorGroup({"step": 3}))
+    trainer.args.ckpt.save_hf = True
+    trainer._prune_hf_checkpoints()
+
+    assert {path.name for path in tmp_path.glob("*_hf")} == {f"{tag}_hf" for tag in retained}
+
+
+def test_rolling_retention_uses_monotonic_best_metric(monkeypatch, tmp_path):
+    monkeypatch.setattr(rl_trainer.ray, "get", lambda refs: refs)
+    actor_group = _ActorGroup({"step": 6})
+    trainer = _trainer(tmp_path, actor_group)
+    trainer.args.logger = SimpleNamespace(logging_steps=1)
+    trainer.args.ckpt.save_steps = 1
+    trainer.best_eval_metric_value = 0.75
+
+    trainer.save_logs_and_checkpoints(6, client_states={"global_step": 6})
+
+    assert actor_group.save_calls[0]["metric_value"] == 0.75
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        pytest.param({"queue_size": 2}, id="async-best"),
+        pytest.param({"save_steps": -1, "force_sync": True}, id="force-sync"),
+        pytest.param({"save_steps": 5, "partial": True, "max_num": 1, "max_mem": 100}, id="partial"),
+        pytest.param({"eval_steps": 25, "save_steps": 1000, "best_metric_key": "none"}, id="best-disabled"),
+        pytest.param({"eval_dataset": "", "eval_steps": -1, "save_steps": 2}, id="eval-disabled"),
+    ],
+)
+def test_best_checkpoint_validation_accepts_supported_modes(monkeypatch, config):
+    strategy = _controller_strategy(**config)
+    monkeypatch.setattr(rl_trainer, "Queue", lambda maxsize: _Queue())
+    monkeypatch.setattr(rl_trainer, "VLLMLock", SimpleNamespace(remote=lambda: object()))
+    monkeypatch.setattr(rl_trainer, "GenerateSamplesActor", SimpleNamespace(remote=lambda **_kwargs: object()))
+    monkeypatch.setattr(rl_trainer, "TrainingActor", SimpleNamespace(remote=lambda **_kwargs: object()))
+    trainer_cls = rl_trainer.RLTrainer.__ray_metadata__.modified_class
+
+    trainer_cls(None, strategy, None, None, None)
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        {"save_steps": -1},
+        {"save_steps": 3},
+        {"save_steps": 5},
+        {"save_steps": 5, "force_sync": True, "queue_size": 2},
+    ],
+)
+def test_async_best_requires_a_rolling_checkpoint_for_every_policy_step(config):
+    strategy = _controller_strategy(**config)
+    trainer_cls = rl_trainer.RLTrainer.__ray_metadata__.modified_class
+
+    with pytest.raises(ValueError, match="save_steps 1"):
+        trainer_cls(None, strategy, None, None, None)
+
+
+@pytest.mark.parametrize(
+    ("config", "message"),
+    [
+        ({"queue_size": 2, "max_num": 2}, "max_num"),
+        ({"queue_size": 2, "max_mem": 100}, "max_mem"),
+    ],
+)
+def test_async_best_rejects_retention_that_can_evict_an_inflight_source(config, message):
+    strategy = _controller_strategy(**config)
+    trainer_cls = rl_trainer.RLTrainer.__ray_metadata__.modified_class
+
+    with pytest.raises(ValueError, match=message):
+        trainer_cls(None, strategy, None, None, None)


### PR DESCRIPTION
## Summary

Async evaluation receives a rollout slot before it acquires the vLLM lock. A
refit can win that race, so the slot number alone does not identify the policy
used to generate the evaluation samples.

The vLLM lock now carries the step of the policy loaded by vLLM. A successful
broadcast publishes its step while releasing the lock. Non-partial evaluation
records the version returned by that same lock. The metric is therefore attached
to the policy that generated the samples in either lock ordering.

When training has already advanced, the trainer promotes the matching
`global_stepN` checkpoint instead of saving the current actor. It stages the
actor, critic, and optional HF export before publishing any destination. The
actor checkpoint is published last as the durable commit marker. A copy or
rename failure rolls back every published destination, removes pending
directories, and leaves the in-memory best metric unchanged. Previous best
checkpoints are pruned only after publication succeeds.

Configurations that can delay a best metric require `--ckpt.save_steps 1`, at
least `async_queue_size + 1` rolling checkpoints, and no disk-size pruning.
`force_sync_mode` is exempt only with one queue slot. The Qwen quick starts and
the 4B, 35B, and Omni3 Slurm recipes now use the required cadence. The 753B smoke recipe keeps its sparse checkpoint cadence and explicitly disables
best-checkpoint selection.

A resumed run recovers the best score from finalized actor metadata and ignores
unfinished `.tmp` and `.old` directories. A fresh run with checkpoint loading
disabled ignores best metadata left in its output directory. HF exports follow
the retained actor tags. Partial rollouts still permit several policy versions
within one evaluation, so that mode skips best-checkpoint selection.

## Testing

- `python -m pytest -q tests/unit/test_rl_trainer.py` (`33 passed`)
- `python -m pytest -q` (`187 passed` on the pre-v0.1.4 tree)
- `python -m compileall -q molt examples/python tests`
- `bash -n examples/scripts/*.sh examples/scripts/quick_start/*.sh examples/scripts/slurm/*.sh`
- `pre-commit run --files <changed files>`
- `git diff --check`

The unit tests cover both outcomes of the rollout-slot/refit race, delayed and
direct saves, two pending metrics, partial rollouts, restart behavior, fresh-run
isolation, HF retention, and the checkpoint configuration matrix. Filesystem
tests inject copy and publication failures independently for actor, critic, and
HF destinations. They check rollback, cleanup, source preservation, and
unchanged metric state, including an `ENOSPC` copy failure. They also cover
recovery of an orphaned `.old` backup and ignoring a `NaN` metric.

## Earlier distributed GPU validation

Before the final transaction and Slurm recipe changes, I ran the parent and a
patched revision consecutively in the same on-demand Verda session in FIN-02 on
2026-07-18 UTC. Both started from
`f6d9191623c3bdc3eada42cde80c0877247636d7`. The production diff executed in
that run has SHA-256
`96a3f06f8edfd75c462f80a74b131a2b4107b4da3a0462c40726ecbdf4e1ffaa`.

That run validates the lock versioning, successful actor promotion, serialized
model and optimizer payloads, and vLLM refits for that exact revision. It is not
byte-for-byte GPU validation of the current diff. The final transaction,
critic/HF failure paths, and additional Slurm defaults are covered locally.

- 8 x NVIDIA A100-SXM4-40GB, with `NV12` between every GPU pair in
  `nvidia-smi topo -m`
- `hijkzzz/molt:0.1.2` at
  `sha256:b9c82365b0c65e9cd4daf0addc34c9a5eba89cfc4593fa2e480246dc7c1dfcd2`
- `Qwen/Qwen3-4B-Instruct-2507` at Hugging Face snapshot
  `cdbee75f17c01a7cc42f958dc650907174af0554`
- 4 actor/reference FSDP2 GPUs and 4 vLLM GPUs with TP=4, NCCL,
  `async_queue_size=2`, `ckpt.save_steps=1`, and non-partial rollouts
- Torch 2.11.0+cu130, CUDA 13.0, Ray 2.55.0, vLLM 0.25.1, and Transformers
  5.8.1

Each run used mixed reward groups, completed four training steps, evaluated
policy step 2 while the trainer reached step 4, and fingerprinted the serialized
model and optimizer payloads. In the patched run, evaluation acquired the lock
first and the step-3 broadcast waited 65.65 seconds. The broadcast-first
ordering is covered by the lock interleaving unit tests.

| tree | metric step | best client step | best serialized payloads match | minimum reward std | minimum actor grad norm | complete vLLM refit checks |
| --- | ---: | ---: | --- | ---: | ---: | ---: |
| parent | 2 | 4 | model and optimizer from `global_step4` | 0.7071 | 0.02829 | 4/4 |
| GPU-tested revision | 2 | 2 | model, optimizer, and file manifest from `global_step2` | 0.7071 | 0.03608 | 4/4 |

<details>
<summary>Checkpoint fingerprints and refit details</summary>

Parent run:

- model: best = step 4 =
  `ddff4b2b4bd24d9c3dd985df2b46b023b446ca25fd7643b4199757846c79da08`,
  while step 2 =
  `215e9ce0b42c7e37523f8f0da6b3446d4bd5df92b8ea67c7c4e735445b1bad66`
- optimizer: best = step 4 =
  `991b9402af2c687b40d855307d3260c7b78ceed31f013b48c481771b59e2be4e`,
  while step 2 =
  `c1243241a5b6c7cd1b66e32fa2bab003b171c81cf5c23ef7bfcbc3226c983319`

GPU-tested revision:

- model: best = step 2 =
  `92072e0bd013d3ff30b90081ce55b8490acece961d5e4246568a46505f6d2aec`,
  while step 4 =
  `341bb2423a0061d9d4941cee7012142caf126819ff2cc16a5570cad622eaada2`
- optimizer: best = step 2 =
  `8fad15d336f9c11fb8deb85950008cfad3db41a2ff0563fd8efb9c413f69e6f8`,
  while step 4 =
  `cd2696ee9a613066495def15f120ae755e6125e4df231a30d7aee6bc9b4b1bea`
- checkpoint file manifest: best = step 2 =
  `4313755ec60143f5a3231717b19f16d2507d977d976010c087c7bcc538f6dfff`,
  while step 4 =
  `05bac86c0bc42a7f1799dde2f29b4ebb0f46df1b3999d3293dc5d28cbea48733`

The run enabled `--train.check_weight_update_equal`. After every broadcast,
all floating-point parameters held by each vLLM worker were reported as
refreshed. vLLM separately ignored one `lm_head.weight` flush per worker and
broadcast. Qwen ties that alias to its input embeddings
(`tie_word_embeddings=true`), so it is not a separate vLLM parameter. The
whole-worker check passed after all four broadcasts.

Harness SHA-256 values:

- runner: `1941c78282d72b02aaff12d9a242e17c72d9c15a6672090755ca05cabfc99b3a`
- mixed-reward environment:
  `6c1bb21877b91961a3571f42454a79b4a595dfd691bd91b4a728f1477b9b4a64`
- checkpoint fingerprint script:
  `81c123bf8a64fecc3b69bf91093f7086b6f52663da90182b5d12d41d2166962e`

</details>

The evidence archive contains sanitized logs, GPU inventory and topology,
runtime and source provenance, payload manifests, copied optimizer metadata,
and four provider-console crops showing Verda, 8 x A100 40GB, FIN-02, and the
running state. It contains no account detail, network address, instance name,
resource identifier, financial field, or raw session identifier. Each run
produced about 180 GiB of checkpoint data. The archive represents the roughly
135 GiB compared subset with per-shard hashes instead of attaching the shards.

Evidence archive: [pr3-verda-a100-evidence.zip](https://github.com/user-attachments/files/30150263/pr3-verda-a100-evidence.zip), SHA-256
`055b7e766e4442ac1063f6c712a39c200655fab6cc9ef68d8372e9b6d6023f93`
