### PR TITLE
feat(observability): log token-weighted advantage mean

### DIFF
--- a/molt/trainer/workers/policy_actor.py
+++ b/molt/trainer/workers/policy_actor.py
@@ -526,6 +526,12 @@ class PolicyTrainer:
             metrics["entropy_loss"] = entropy_loss.detach()
             weights["entropy_loss"] = "token"
 
+        # Action-token-weighted mean of the policy advantages. The aggregate is
+        # near zero when batch whitening is enabled; otherwise it is the raw
+        # policy-signal mean.
+        metrics["advantage_mean"] = masked_mean(advantages, action_mask).detach()
+        weights["advantage_mean"] = "token"
+
         metrics["actor_lr"] = self.actor_scheduler.get_last_lr()[0]
         weights["actor_lr"] = None
         # grad_norm is meaningful only on the optimizer-step microbatch, where


### PR DESCRIPTION
The policy advantages used by the actor loss were not exposed as a training metric. Log their action-token-weighted mean alongside the existing actor metrics.

For estimators that batch-whiten advantages, this value should remain near zero. For estimators that skip whitening, or when whitening is disabled, it reports the raw policy-signal mean.

No training behavior change.