### PR TITLE
docs(cli): fix --actor.entropy_coef help to match behavior

### DIFF
--- a/molt/cli/train_rl_ray.py
+++ b/molt/cli/train_rl_ray.py
@@ -512,7 +512,11 @@ if __name__ == "__main__":
         "--actor.entropy_coef",
         type=float,
         default=None,
-        help="Entropy loss coef, set to 0 means only enable entropy logs",
+        help=(
+            "Entropy coefficient. Any nonzero value enables entropy computation and "
+            "logs entropy_loss; positive values encourage higher entropy. "
+            "0 or unset skips entropy computation."
+        ),
     )
     parser.add_argument("--reward.clip_range", type=float, nargs=2, default=(-10, 10), help="Reward clip range")
 


### PR DESCRIPTION
The help said "set to 0 means only enable entropy logs", but both entropy computation and the entropy_loss metric are gated on bool(entropy_coef). Thus, 0 or unset skips entropy computation and logging, while any nonzero value enables both; positive values encourage higher entropy.

Correct the help text to reflect the implementation. No behavior change.