### PR TITLE
feat(vllm): expose NCCL fallback for tensor-parallel all-reduce

### DIFF
--- a/molt/cli/train_rl_ray.py
+++ b/molt/cli/train_rl_ray.py
@@ -89,6 +89,7 @@ def train(args):
             mamba_ssm_cache_dtype=args.vllm.mamba_ssm_cache_dtype,
             distributed_executor_backend=args.vllm.distributed_executor_backend,
             enable_expert_parallel=args.vllm.enable_expert_parallel,
+            disable_custom_all_reduce=args.vllm.disable_custom_all_reduce,
             enable_prefix_caching=args.vllm.enable_prefix_caching,
             enable_chunked_prefill=args.vllm.enable_chunked_prefill,
             max_num_batched_tokens=args.vllm.max_num_batched_tokens,
@@ -619,6 +620,16 @@ if __name__ == "__main__":
         action="store_true",
         default=False,
         help="Enable vLLM TP+EP hybrid: experts EP-sharded across the TP ranks (Qwen3.5/3.6 MoE).",
+    )
+    parser.add_argument(
+        "--vllm.disable_custom_all_reduce",
+        action="store_true",
+        default=False,
+        help=(
+            "Disable vLLM's custom all-reduce kernel and fall back to NCCL. "
+            "Useful when custom all-reduce fails because GPU P2P or CUDA IPC "
+            "is unavailable or incompatible."
+        ),
     )
     # vLLM throughput features. We leave `chunked_prefill` and `async_scheduling`
     # at None so vLLM 0.21's own auto-resolution decides (both default ON for

--- a/molt/trainer/vllm/vllm_engine.py
+++ b/molt/trainer/vllm/vllm_engine.py
@@ -275,6 +275,7 @@ def create_vllm_engines(
     mamba_ssm_cache_dtype: Optional[str] = None,
     distributed_executor_backend: Optional[str] = None,
     enable_expert_parallel: bool = False,
+    disable_custom_all_reduce: bool = False,
     # vLLM 0.21 EngineArgs accept None and resolve internally to its own default
     # (prefix_caching True, chunked_prefill True, async_scheduling True for
     # mp/uniproc executors). We override only `enable_prefix_caching` to False:
@@ -469,6 +470,13 @@ def create_vllm_engines(
             # vLLM TP+EP hybrid: non-MoE layers stay TP-sharded across `tensor_parallel_size`
             # ranks; MoE experts are EP-distributed across the same ranks (one group per rank).
             actor_kwargs["enable_expert_parallel"] = True
+
+        if disable_custom_all_reduce:
+            # Fall back from vLLM's custom all-reduce to NCCL for cross-GPU TP reductions.
+            # The custom kernel needs supported GPU P2P / CUDA IPC, which can be unavailable
+            # or incompatible on some multi-GPU / container hosts (e.g. custom_all_reduce.cuh
+            # "invalid argument"), where TP>1 rollout otherwise crashes at engine init.
+            actor_kwargs["disable_custom_all_reduce"] = True
 
         if data_parallel_size > 1:
             # vLLM EP = TP * DP: raising DP is the only way a rollout engine gets

--- a/tests/unit/test_vllm_engine.py
+++ b/tests/unit/test_vllm_engine.py
@@ -103,6 +103,22 @@ def test_filter_vllm_engine_kwargs_keeps_speculative_config(monkeypatch):
     assert filtered == {"model": "m", "speculative_config": {"num_speculative_tokens": 1}}
 
 
+def test_filter_vllm_engine_kwargs_keeps_disable_custom_all_reduce(monkeypatch):
+    # --vllm.disable_custom_all_reduce threads through as this kwarg; it is a real
+    # AsyncEngineArgs field, so it must survive the whitelist filter (a rename/typo
+    # would otherwise let it be silently dropped -> flag becomes a no-op).
+    @dataclass
+    class FakeAsyncEngineArgs:
+        model: str
+        disable_custom_all_reduce: bool = False
+
+    monkeypatch.setattr(vllm_engine.vllm, "AsyncEngineArgs", FakeAsyncEngineArgs)
+
+    filtered = vllm_engine._filter_vllm_engine_kwargs({"model": "m", "disable_custom_all_reduce": True})
+
+    assert filtered == {"model": "m", "disable_custom_all_reduce": True}
+
+
 def test_ray_visible_device_flag_is_cuda_only():
     assert vllm_engine.ray_noset_visible_devices({"RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES": "1"})
     assert not vllm_engine.ray_noset_visible_devices({"RAY_EXPERIMENTAL_NOSET_OTHER_VISIBLE_DEVICES": "1"})


### PR DESCRIPTION
## What

Add `--vllm.disable_custom_all_reduce` and thread it through
`create_vllm_engines` to vLLM's `AsyncEngineArgs`.

It defaults to `False`, preserving vLLM's default behavior. TP=1 is
unaffected.

## Why

vLLM's custom all-reduce path relies on compatible GPU P2P/CUDA IPC.
In some multi-GPU or container environments, that path can fail during
TP>1 engine initialization with errors such as:

`custom_all_reduce.cuh: invalid argument`

vLLM supports disabling its custom kernel and falling back to NCCL, but
Molt previously had no way to configure that behavior.

## Verification

Tested with Qwen3-4B, TP=2, on 2×A100:

- **Flag reaches vLLM:** the engine configuration reports
  `disable_custom_all_reduce=True`, confirming that the value survives
  `_filter_vllm_engine_kwargs` and reaches the real `AsyncEngineArgs`
  field.
- **NCCL-path initialization succeeds:** with the flag enabled, the TP=2
  engine loads its weights, builds the KV cache, and completes
  initialization (`init engine took 5.34s`).
- **Unit test:** verifies that `_filter_vllm_engine_kwargs` preserves
  `disable_custom_all_reduce` when supported by `AsyncEngineArgs`.
- `compileall` passes.
- All 6 vLLM unit tests pass.

This host does not reproduce the custom-all-reduce initialization
failure because its P2P configuration is compatible. The test therefore
verifies the configuration path and NCCL fallback mechanism, rather than
reproducing the original failure locally.