### PR TITLE
fix(refit): skip redundant tied lm_head update

### DIFF
--- a/molt/trainer/workers/policy_actor.py
+++ b/molt/trainer/workers/policy_actor.py
@@ -46,6 +46,17 @@ from .actor_group import BaseModelActor
 logger = init_logger(__name__)
 
 
+def _skip_tied_lm_head(config, name: str) -> bool:
+    """Whether to skip broadcasting this weight to vLLM as a redundant tied lm_head.
+
+    Tied-embedding models share lm_head with embed_tokens; vLLM receives the shared
+    weight through embed_tokens, so a separate lm_head.weight update is redundant and
+    would form an empty "loaded 0 of N" refit batch. Exact-match only (``lm_head.weight``)
+    so nested/auxiliary heads like ``mtp.lm_head.weight`` are still sent.
+    """
+    return bool(getattr(config, "tie_word_embeddings", False)) and name == "lm_head.weight"
+
+
 class PolicyTrainer:
     """Owns actor-side policy optimization on each Ray/FSDP worker."""
 
@@ -577,6 +588,7 @@ class PolicyTrainer:
         from torch.distributed.tensor import DTensor
 
         ep_size = getattr(self.strategy.args.fsdp, "ep_size", 1) or 1
+        model_config = getattr(model, "config", None)
 
         # Pack many small per-tensor broadcasts into large batched broadcasts.
         # Inspired by vLLM's `vllm.distributed.weight_transfer.packed_tensor`
@@ -670,6 +682,8 @@ class PolicyTrainer:
             for hf_name, hf_weight in hf_pairs:
                 if not torch.is_tensor(hf_weight) or not hf_weight.is_floating_point():
                     continue
+                if _skip_tied_lm_head(model_config, hf_name):
+                    continue  # redundant: vLLM gets the shared weight via embed_tokens
                 # Dtype-faithful refit: keep each param in its native/compute dtype
                 # instead of force-casting everything to a single `param_dtype`. vLLM's
                 # `load_weights` casts each tensor to *that param's own* target dtype via

--- a/tests/unit/test_refit_tied_lm_head.py
+++ b/tests/unit/test_refit_tied_lm_head.py
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Which weights broadcast_to_vllm skips as a redundant tied lm_head.
+
+Tied-embedding models (tie_word_embeddings=true) share lm_head with embed_tokens;
+vLLM receives the shared weight via embed_tokens, so sending lm_head.weight forms an
+empty "loaded 0 of N" refit batch. The skip must be exact-match: only lm_head.weight,
+and only when tied — never embed_tokens or a nested/auxiliary head (mtp/draft).
+"""
+
+from types import SimpleNamespace
+
+from molt.trainer.workers.policy_actor import _skip_tied_lm_head
+
+
+def _cfg(tied: bool):
+    return SimpleNamespace(tie_word_embeddings=tied)
+
+
+def test_tied_lm_head_is_skipped():
+    assert _skip_tied_lm_head(_cfg(True), "lm_head.weight") is True
+
+
+def test_tied_embed_tokens_is_kept():
+    assert _skip_tied_lm_head(_cfg(True), "model.embed_tokens.weight") is False
+
+
+def test_untied_lm_head_is_kept():
+    assert _skip_tied_lm_head(_cfg(False), "lm_head.weight") is False
+
+
+def test_tied_nested_head_is_kept():
+    # An auxiliary head (e.g. MTP / draft model) is a distinct output weight, not the
+    # tied lm_head — exact match keeps it (endswith would have wrongly skipped it).
+    assert _skip_tied_lm_head(_cfg(True), "mtp.lm_head.weight") is False


### PR DESCRIPTION
## What

Skip broadcasting the exact `lm_head.weight` entry during
`broadcast_to_vllm` when the model has tied word embeddings.

This eliminates a false-positive refit warning while preserving
`embed_tokens.weight` and nested or auxiliary heads such as
`mtp.lm_head.weight`.

## Why

Tied-embedding models such as Qwen3-4B
(`tie_word_embeddings=true`) share the output projection with the input
embeddings. vLLM receives the shared weight through `embed_tokens`, so a
separate `lm_head.weight` update is redundant.

Molt previously sent it anyway. In this refit path, vLLM matched no
weight for that entry, producing a solo flush with:

`[refit] WARNING: loaded 0 of N ... rollout stays stale`

The warning is a false positive: the actual model weights still
synchronize successfully.

## Verification

Qwen3-4B smoke test through global step 1 with
`--train.check_weight_update_equal`:

| | `[refit] WARNING` | `[check_weight_update]` |
|---|---|---|
| Before | Fires for `lm_head.weight` | All parameters refreshed |
| After | None | All parameters refreshed |

Additional checks:

- Added four unit cases:
  - tied + exact `lm_head.weight` → skipped
  - tied + `embed_tokens.weight` → retained
  - untied + `lm_head.weight` → retained
  - tied + nested `mtp.lm_head.weight` → retained
- 4/4 unit tests pass.
- `compileall` passes.

No change to the actual weight synchronization.