### PR TITLE
perf(rl): vectorize default REINFORCE returns

### DIFF
--- a/molt/trainer/algorithm/advantage.py
+++ b/molt/trainer/algorithm/advantage.py
@@ -151,11 +151,14 @@ def reinforce(
         token_reward = token_reward * mask
 
         # discounted reverse-cumulative returns: G_t = r_t + gamma * G_{t+1}
-        seq_returns = torch.zeros_like(token_reward)
-        running = torch.zeros(token_reward.size(0), device=token_reward.device)
-        for t in reversed(range(token_reward.size(1))):
-            running = token_reward[:, t] + ctx.gamma * running
-            seq_returns[:, t] = running
+        if ctx.gamma == 1.0:
+            seq_returns = token_reward.flip(1).cumsum(1).flip(1)
+        else:
+            seq_returns = torch.zeros_like(token_reward)
+            running = torch.zeros(token_reward.size(0), device=token_reward.device)
+            for t in reversed(range(token_reward.size(1))):
+                running = token_reward[:, t] + ctx.gamma * running
+                seq_returns[:, t] = running
         returns.append(seq_returns)
 
     return normalize_advantages(returns, ctx), returns

--- a/tests/unit/test_gae_value_loss.py
+++ b/tests/unit/test_gae_value_loss.py
@@ -276,6 +276,41 @@ def test_reinforce_returns_and_advantages():
     assert torch.allclose(advantages[0], torch.tensor([[1.0, 1.0, 1.0], [-1.0, -1.0, -1.0]]), atol=1e-5)
 
 
+def test_reinforce_returns_match_reverse_recursion_with_masked_kl_rewards():
+    """The gamma=1 fast path and discounted fallback preserve the token-level
+    reverse recurrence across masked observation tokens."""
+    reinforce = adv_mod.get_advantage_estimator("reinforce")
+    mask = torch.tensor([[1, 0, 1, 1, 0], [0, 1, 1, 0, 0]], dtype=torch.float32)
+    kl = torch.tensor([[0.5, 9.0, -0.25, 0.75, -4.0], [3.0, -0.5, 0.25, 8.0, -2.0]])
+    rewards = torch.tensor([2.0, -1.0])
+    token_reward = -0.2 * kl * mask
+    token_reward[0, 3] += rewards[0]
+    token_reward[1, 2] += rewards[1]
+
+    for gamma in (1.0, 0.75):
+        expected = torch.zeros_like(token_reward)
+        running = torch.zeros(token_reward.size(0))
+        for t in reversed(range(token_reward.size(1))):
+            running = token_reward[:, t] + gamma * running
+            expected[:, t] = running
+
+        ctx = AdvantageContext(
+            sample_to_rollout=torch.arange(2),
+            exp_len=[2],
+            action_masks=[mask],
+            kl_coef=0.2,
+            gamma=gamma,
+            lam=1.0,
+            kls=[kl],
+            values=None,
+            no_whiten=True,
+        )
+        advantages, returns = reinforce(rewards, [[0], [1]], ctx)
+
+        torch.testing.assert_close(returns[0], expected)
+        torch.testing.assert_close(advantages[0], expected)
+
+
 def test_value_loss_matches_reference():
     """ValueLoss must equal 0.5 * max(clipped^2, unclipped^2) (the standard PPO
     0.5 factor), aggregated as a plain masked mean over the active tokens."""


### PR DESCRIPTION
## Summary

Default REINFORCE uses `gamma=1`, where its reverse return recurrence is an undiscounted cumulative sum. The existing Python loop performs one controller-side dispatch per token, adding seconds of CPU latency at long context lengths.

Use `flip().cumsum().flip()` for that default path. The existing recurrence remains unchanged for `gamma != 1`, and masked GAE is intentionally out of scope.

The regression test checks both paths with interior masked observation tokens, nonzero per-token KL rewards, and terminal outcome rewards.

Closes #28.

## Performance

Measured in one process on a 4-vCPU DO-Premium-AMD host with PyTorch 2.11.0, one CPU thread, one experience, batch size 1, `gamma=1`, and `no_whiten=True`. Each cell is the median of three runs of the complete estimator against the same tensors and context.

| Sequence length | Before | After | Speedup |
| ---: | ---: | ---: | ---: |
| 32,768 | 1,059.653 ms | 0.894 ms | 1,185.3x |
| 65,536 | 2,144.341 ms | 1.075 ms | 1,993.9x |
| 131,072 | 4,626.088 ms | 1.867 ms | 2,477.7x |

Both paths accumulate FP32 `token_reward` values. As expected for a different floating-point reduction order, a separate 128K synthetic run with noisy per-token rewards produced a maximum absolute return difference of `4.43e-5` from the scalar recurrence.

## Testing

- `PYTHONPATH=. pytest tests/unit` — 169 passed
- `pre-commit run --files molt/trainer/algorithm/advantage.py tests/unit/test_gae_value_loss.py` — passed
- `git diff --check origin/main...HEAD` — passed
