### PR TITLE
fix: make Ray actor __init__ methods synchronous

### DIFF
--- a/molt/trainer/rollout/router.py
+++ b/molt/trainer/rollout/router.py
@@ -292,7 +292,7 @@ class AgentRunnerActor:
     (``--rollout.num_runners``) parallelizes that work; the trainer round-robins prompts
     across them (no pool wrapper — just a list + an index)."""
 
-    async def __init__(self, agent_path, router_url, *, model_path=None, model_name="policy"):
+    def __init__(self, agent_path, router_url, *, model_path=None, model_name="policy"):
         import aiohttp
 
         from molt.agents.base import load_agent_runner  # lazy: router.py is imported by _chat_server

--- a/molt/trainer/vllm/vllm_engine.py
+++ b/molt/trainer/vllm/vllm_engine.py
@@ -101,7 +101,7 @@ def _filter_vllm_engine_kwargs(kwargs: dict) -> dict:
 class RolloutRayActor:
     """Async vLLM-backed actor that exposes generation utilities."""
 
-    async def __init__(self, *args, bundle_indices: list = None, **kwargs):
+    def __init__(self, *args, bundle_indices: list = None, **kwargs):
         backend = kwargs.get("distributed_executor_backend")
         num_gpus = kwargs.pop("num_gpus")
         self._configure_device_env(

--- a/tests/unit/test_router.py
+++ b/tests/unit/test_router.py
@@ -15,6 +15,7 @@
 
 import asyncio
 import base64
+import inspect
 import io
 from types import SimpleNamespace
 
@@ -23,6 +24,7 @@ import numpy as np
 import pytest
 
 from molt.trainer.rollout.router import (
+    AgentRunnerActor,
     RouterGenerateClient,
     _align_features_to_canonical,
     _decode_routed_experts,
@@ -258,3 +260,9 @@ def test_align_features_multi_image_finds_separated_runs():
 def test_decode_routed_experts_handles_both_encodings():
     assert _decode_routed_experts(_npy_b64([[1], [2]])).tolist() == [[1], [2]]  # base64 .npy
     assert _decode_routed_experts([[3], [4]]).tolist() == [[3], [4]]  # nested JSON lists
+
+
+def test_agent_runner_actor_init_is_synchronous():
+    """Ray actor constructors are synchronous; an async __init__ would not be awaited."""
+    actor_cls = getattr(AgentRunnerActor, "__ray_actor_class__", AgentRunnerActor)
+    assert not inspect.iscoroutinefunction(actor_cls.__init__)

--- a/tests/unit/test_vllm_engine.py
+++ b/tests/unit/test_vllm_engine.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import inspect
 import sys
 from dataclasses import dataclass
 from types import ModuleType
@@ -122,3 +123,9 @@ def test_filter_vllm_engine_kwargs_keeps_disable_custom_all_reduce(monkeypatch):
 def test_ray_visible_device_flag_is_cuda_only():
     assert vllm_engine.ray_noset_visible_devices({"RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES": "1"})
     assert not vllm_engine.ray_noset_visible_devices({"RAY_EXPERIMENTAL_NOSET_OTHER_VISIBLE_DEVICES": "1"})
+
+
+def test_rollout_ray_actor_init_is_synchronous():
+    """Ray actor constructors are synchronous; an async __init__ would not be awaited."""
+    actor_cls = getattr(vllm_engine.RolloutRayActor, "__ray_actor_class__", vllm_engine.RolloutRayActor)
+    assert not inspect.iscoroutinefunction(actor_cls.__init__)


### PR DESCRIPTION
## Bug

`RolloutRayActor` and `AgentRunnerActor` declared `async def __init__`. Ray actor constructors are synchronous; Ray does not await an async `__init__`, so the initialization coroutine was either skipped or left pending, causing the actor to be unusable or to fail at runtime.

## Fix

Change both constructors to regular synchronous `def __init__`. The bodies were already doing only synchronous work, so no other changes are required.

## Test

Added regression tests in `tests/unit/test_vllm_engine.py` and `tests/unit/test_router.py` that assert the actor `__init__` methods are not coroutine functions.

## Verification

`python -m py_compile molt/trainer/vllm/vllm_engine.py molt/trainer/rollout/router.py` passes. The new unit tests exercise the existing test modules and will run in CI where Ray is available.