### PR TITLE
fix: ensure ChatAgent prompt_text is always a string

### DIFF
--- a/molt/agents/chat_agent.py
+++ b/molt/agents/chat_agent.py
@@ -145,6 +145,34 @@ def _pil_data_uri(pil) -> str:
     return "data:image/png;base64," + base64.b64encode(buf.getvalue()).decode()
 
 
+def _extract_text_from_content(content) -> str:
+    """Flatten a message's content to a plain-text string without loading images."""
+    if isinstance(content, str):
+        return content
+    if not isinstance(content, list):
+        return "" if content is None else str(content)
+    parts = []
+    for item in content:
+        if isinstance(item, dict) and item.get("type") == "text":
+            parts.append(item.get("text") or "")
+    return "".join(parts)
+
+
+def _extract_prompt_text(prompt) -> str:
+    """Return a scalar text view of the last user turn in a prompt row."""
+    raw = prompt if isinstance(prompt, list) else [{"role": "user", "content": str(prompt)}]
+    user_texts = [
+        m["content"] for m in raw if m.get("role") == "user" and isinstance(m.get("content"), str)
+    ]
+    if user_texts:
+        return user_texts[-1]
+
+    last_user = next((m for m in reversed(raw) if m.get("role") == "user"), None)
+    if last_user is None:
+        return ""
+    return _extract_text_from_content(last_user.get("content"))
+
+
 def _wire_messages(prompt, images) -> list:
     """Dataset row -> OpenAI wire-format messages, ready to send verbatim.
 
@@ -231,9 +259,7 @@ class ChatAgentRunner(Runner):
         messages = _wire_messages(prompt, images)
         # Scalar view of the task for grading/logging (and Trajectory.prompt): the last user
         # turn's text — taken from the RAW row (wire messages may have inlined its images).
-        raw = prompt if isinstance(prompt, list) else [{"role": "user", "content": str(prompt)}]
-        user_texts = [m["content"] for m in raw if m.get("role") == "user" and isinstance(m.get("content"), str)]
-        prompt_text = user_texts[-1] if user_texts else prompt
+        prompt_text = _extract_prompt_text(prompt)
         # Pass THIS call's sampling_params so the server defaults each turn to the right train-vs-eval
         # temperature/max_tokens even if the agent doesn't re-send them (see _Session.sampling_params).
         self._state.open(session_id, prompt_text, label, images, sampling_params)

--- a/tests/unit/test_chat_agent.py
+++ b/tests/unit/test_chat_agent.py
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for chat-agent prompt helpers."""
+
+import pytest
+
+
+def _import_helpers():
+    try:
+        from molt.agents.chat_agent import _extract_prompt_text
+    except ImportError as exc:
+        pytest.skip(f"chat_agent dependencies not available: {exc}")
+    return _extract_prompt_text
+
+
+def test_extract_prompt_text_uses_last_string_user_turn():
+    _extract_prompt_text = _import_helpers()
+    prompt = [
+        {"role": "system", "content": "system"},
+        {"role": "user", "content": "first"},
+        {"role": "user", "content": "last"},
+    ]
+    assert _extract_prompt_text(prompt) == "last"
+
+
+def test_extract_prompt_text_handles_scalar_prompt():
+    _extract_prompt_text = _import_helpers()
+    assert _extract_prompt_text("plain prompt") == "plain prompt"
+
+
+def test_extract_prompt_text_extracts_text_from_structured_content():
+    _extract_prompt_text = _import_helpers()
+    prompt = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "hello "},
+                {"type": "image_url", "image_url": {"url": "data:image/png;base64,abc"}},
+                {"type": "text", "text": "world"},
+            ],
+        }
+    ]
+    assert _extract_prompt_text(prompt) == "hello world"
+
+
+def test_extract_prompt_text_returns_empty_string_when_no_user_turn():
+    _extract_prompt_text = _import_helpers()
+    assert _extract_prompt_text([{"role": "system", "content": "system only"}]) == ""


### PR DESCRIPTION
## Bug

`ChatAgent.execute` set `prompt_text` to the last string user turn, but fell back to the raw `prompt` when no string user content existed. For multimodal dataset rows the raw prompt is a list of messages, so `ChatContext.prompt` (typed `str`) received a list and downstream consumers expecting a scalar task description could break.

## Fix

Introduce `_extract_prompt_text` to flatten the last user turn into a plain string without loading images. It handles string content, structured/image content, and system-only prompts gracefully.

## Test

Added `tests/unit/test_chat_agent.py` with tests for:
- last string user turn selection
- scalar string prompts
- structured content text extraction
- empty fallback for system-only prompts

## Verification

`python -m py_compile molt/agents/chat_agent.py` passes. The new unit tests run in the existing labs-molt test environment.