### PR TITLE
refactor(chat-agent): collapse prompt-text extraction into one helper

### DIFF
--- a/molt/agents/chat_agent.py
+++ b/molt/agents/chat_agent.py
@@ -145,32 +145,21 @@ def _pil_data_uri(pil) -> str:
     return "data:image/png;base64," + base64.b64encode(buf.getvalue()).decode()
 
 
-def _extract_text_from_content(content) -> str:
-    """Flatten a message's content to a plain-text string without loading images."""
+def _extract_prompt_text(prompt) -> str:
+    """Scalar text view of the last user turn: its text parts joined, images skipped.
+
+    Multimodal rows carry list content ([{type:text}, {type:image_url}, ...]); keeping only
+    the text guarantees ChatContext.prompt / grading always receive a plain string.
+    """
+    if not isinstance(prompt, list):
+        return str(prompt)
+    last_user = next((m for m in reversed(prompt) if m.get("role") == "user"), None)
+    content = last_user.get("content") if last_user else ""
     if isinstance(content, str):
         return content
     if not isinstance(content, list):
         return "" if content is None else str(content)
-    parts = []
-    for item in content:
-        if isinstance(item, dict) and item.get("type") == "text":
-            parts.append(item.get("text") or "")
-    return "".join(parts)
-
-
-def _extract_prompt_text(prompt) -> str:
-    """Return a scalar text view of the last user turn in a prompt row."""
-    raw = prompt if isinstance(prompt, list) else [{"role": "user", "content": str(prompt)}]
-    user_texts = [
-        m["content"] for m in raw if m.get("role") == "user" and isinstance(m.get("content"), str)
-    ]
-    if user_texts:
-        return user_texts[-1]
-
-    last_user = next((m for m in reversed(raw) if m.get("role") == "user"), None)
-    if last_user is None:
-        return ""
-    return _extract_text_from_content(last_user.get("content"))
+    return "".join(part.get("text") or "" for part in content if isinstance(part, dict) and part.get("type") == "text")
 
 
 def _wire_messages(prompt, images) -> list:

--- a/tests/unit/test_chat_agent.py
+++ b/tests/unit/test_chat_agent.py
@@ -59,3 +59,20 @@ def test_extract_prompt_text_extracts_text_from_structured_content():
 def test_extract_prompt_text_returns_empty_string_when_no_user_turn():
     _extract_prompt_text = _import_helpers()
     assert _extract_prompt_text([{"role": "system", "content": "system only"}]) == ""
+
+
+def test_extract_prompt_text_follows_last_user_turn_over_earlier_string():
+    """The scalar view is the LAST user turn's text, even when an earlier user turn was a
+    plain string and the final one carries structured (text + image) content."""
+    _extract_prompt_text = _import_helpers()
+    prompt = [
+        {"role": "user", "content": "earlier"},
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "final"},
+                {"type": "image_url", "image_url": {"url": "data:image/png;base64,abc"}},
+            ],
+        },
+    ]
+    assert _extract_prompt_text(prompt) == "final"


### PR DESCRIPTION
_extract_prompt_text now folds the former _extract_text_from_content into a single pass: take the last user turn and join its text parts (images skipped), replacing two single-call-site helpers and the "last string user turn, else flatten" two-pass. Also drops the throwaway message wrapper for scalar prompts. Same string-always guarantee; now follows the actual last user turn even when an earlier turn was a plain string (covered by a new test).