### PR TITLE
refactor(docker): drop FLASHINFER_DISABLE_VERSION_CHECK — cubin isn't…

### DIFF
--- a/dockerfile/Dockerfile
+++ b/dockerfile/Dockerfile
@@ -197,12 +197,6 @@ RUN python -m pip install --no-cache-dir "tilelang==0.1.11" "tile-kernels==1.0.0
 # is container-local, so every job would recompile the DSA kernels from scratch.
 ENV TILELANG_CACHE_DIR=/root/.cache/tilelang
 
-# vLLM 0.26 hard-pins flashinfer-python==0.6.14, but flashinfer-cubin was never published past
-# 0.6.13, so `import flashinfer` RuntimeErrors on the version mismatch. No matching pair exists,
-# so bypass the check — flashinfer JIT-compiles any kernel missing from the 0.6.13 cubins (a
-# prefill attention op verified working on an A100 this way).
-ENV FLASHINFER_DISABLE_VERSION_CHECK=1
-
 # vLLM 0.26 hard-pins nvidia-cutlass-dsl==4.6.0, whose cutlass.cute DSL dropped `ThrMma`. The
 # quack-kernels that dion pulls can lag that API and then AttributeError at import, taking
 # `import mamba_ssm` (mamba3 -> quack) down with it. Pin quack to the 4.6.0-compatible 0.6.1.


### PR DESCRIPTION
… installed

A from-scratch build installs flashinfer-python (via vLLM 0.26) but NOT flashinfer-cubin — nothing depends on it. With no cubin package present there is no version to mismatch, so `import flashinfer` succeeds without the bypass and flashinfer fetches/JITs the cubins it needs at runtime (as intended upstream). The env only ever mattered for incrementally-built images that inherited a stale flashinfer-cubin 0.6.13 from an older base.

Verified: a full-build image has `flashinfer-cubin: NOT INSTALLED`, and `import flashinfer` + a prefill-attention kernel run on an A100 with FLASHINFER_DISABLE_VERSION_CHECK unset. The build-time import self-check (which imports flashinfer) still passes without the env.