### PR TITLE
feat(docker): CUDA forward compatibility for old-driver Data Center h…

### DIFF
--- a/dockerfile/Dockerfile
+++ b/dockerfile/Dockerfile
@@ -220,6 +220,15 @@ RUN python -m pip install --no-deps --force-reinstall nvidia-nvshmem-cu13==3.6.5
 RUN { find ${SITE}/nvidia -mindepth 2 -maxdepth 2 -type d -name lib | sort; echo ${SITE}/z3/lib; } \
         > /etc/ld.so.conf.d/python-nvidia-libs.conf && ldconfig
 
+# --- CUDA forward compatibility -------------------------------------------------
+# Ship cuda-compat-13-0 (the CUDA 13.0 forward-compat libcuda) so the stack can run on Data
+# Center hosts whose NVIDIA kernel driver is older than 580 (native CUDA 13). It lands in
+# /usr/local/cuda/compat and is NOT on the loader path by default — docker-entrypoint.sh
+# prepends it at runtime only when the detected host driver is < 580, so native-driver hosts
+# are unaffected. (Do NOT ldconfig it in — that would force it on every host.)
+RUN apt-get update && apt-get install -y --no-install-recommends cuda-compat-13-0 && \
+    rm -rf /var/lib/apt/lists/*
+
 # --- build-time import self-check -----------------------------------------------
 # Fail the build if the installed stack can't import, so a dependency bump can't ship an image
 # that only crashes at a user's runtime — e.g. the quack-vs-cutlass-DSL drift that broke

--- a/dockerfile/docker-entrypoint.sh
+++ b/dockerfile/docker-entrypoint.sh
@@ -35,5 +35,28 @@ else
     export PATH=/root/.local/bin/:$PATH
 fi
 
+# --- CUDA forward compatibility -------------------------------------------------
+# The stack is CUDA 13; a host NVIDIA kernel driver older than 580 (the CUDA 13.0 GA
+# driver) can't run it natively. On Data Center GPUs, cuda-compat ships a newer userspace
+# libcuda that bridges to the older kernel driver. Prepend it to the loader path ONLY when
+# the host driver is too old, so hosts with a native CUDA-13 driver keep using theirs.
+# Override: MOLT_CUDA_COMPAT=1 forces on, =0 forces off (default: auto-detect).
+COMPAT_DIR=/usr/local/cuda/compat
+if [[ -d "${COMPAT_DIR}" ]]; then
+    # Host kernel-driver major. nvidia-smi reads host NVML (unaffected by compat/libcuda);
+    # /proc/driver/nvidia/version is a fallback (not always mounted in the container).
+    DRV=$(nvidia-smi --query-gpu=driver_version --format=csv,noheader 2>/dev/null | head -1 | cut -d. -f1)
+    [[ -z "${DRV}" ]] && DRV=$(grep -oE 'Kernel Module +[0-9]+' /proc/driver/nvidia/version 2>/dev/null | grep -oE '[0-9]+$')
+    case "${MOLT_CUDA_COMPAT:-auto}" in
+        1|on|force) USE_COMPAT=1 ;;
+        0|off)      USE_COMPAT= ;;
+        *)          if [[ -n "${DRV}" && "${DRV}" -lt 580 ]]; then USE_COMPAT=1; else USE_COMPAT=; fi ;;
+    esac
+    if [[ -n "${USE_COMPAT}" ]]; then
+        export LD_LIBRARY_PATH="${COMPAT_DIR}:${LD_LIBRARY_PATH}"
+        echo "[molt] CUDA forward-compat ON (host driver=${DRV:-unknown} < 580) -> ${COMPAT_DIR}"
+    fi
+fi
+
 cd $HOME
 exec gosu ${USER} "$@"


### PR DESCRIPTION
…osts

The CUDA-13 stack needs a host NVIDIA kernel driver >= 580 (CUDA 13.0 GA) to run natively, so it can't start on DC hosts still on e.g. R535. Ship cuda-compat-13-0 (the 580.173.02 forward-compat libcuda) and have docker-entrypoint.sh prepend it to LD_LIBRARY_PATH only when the host driver is < 580 — detected via nvidia-smi (host NVML, unaffected by compat), with /proc/driver/nvidia/version as fallback. MOLT_CUDA_COMPAT=1/0 forces on/off.

compat is NOT ldconfig'd in (that would force the old libcuda on every host, which errors on a native >=580 driver — verified: forcing it on a 595 host gives CUDA error 803). So native- driver hosts are unaffected (verified on a 595 host: auto-mode detects 595, skips compat, native CUDA works), and old-driver DC hosts get the forward-compat bridge.