### PR TITLE
chore: update claude review to FW-CI-templates v1.8.5

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -27,7 +27,7 @@ permissions:
 
 jobs:
   claude-review:
-    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_claude_review.yml@209ac7913b0419a5ccbac47b02d00fbea4939243 # v1.8.4
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_claude_review.yml@fe0ff3bbe10790c51273ee3c1189b3c0497bf860 # v1.8.5
     with:
       model: ${{ vars.CLAUDE_MODEL }}
       prompt: |


### PR DESCRIPTION
Bumps the pinned SHA for `_claude_review.yml` to FW-CI-templates `v1.8.5` (`fe0ff3bbe10790c51273ee3c1189b3c0497bf860`).

**What changed in v1.8.5:**
- fix: tolerate trailing whitespace in `/claude review` trigger phrase

cc @kajalj