### PR TITLE
fix(rollout): require complete groups for group estimators

### DIFF
--- a/molt/trainer/rollout/samples_generator.py
+++ b/molt/trainer/rollout/samples_generator.py
@@ -28,6 +28,7 @@ from tqdm import tqdm
 from vllm import SamplingParams
 
 from molt.agents.base import _first_scalar as _to_scalar  # dedupe: same tensor/list/scalar normalizer
+from molt.trainer.algorithm.advantage import GROUP_ADVANTAGE_ESTIMATORS
 from molt.trainer.algorithm.experience import Experience
 from molt.utils.logging_utils import init_logger
 
@@ -207,6 +208,9 @@ class SamplesGenerator:
         groups_per_batch = self.args.rollout.batch_size
         inflight_capacity = getattr(self.args.rollout, "vllm_generate_batch_size", None) or groups_per_batch
         dynamic_filtering = self.args.algo.dynamic_filtering_enable
+        # Only group-advantage estimators need every group to keep all n_samples rollouts
+        # (a partial group changes its intended statistics/baselines); per-sample estimators don't.
+        require_complete_group = self.args.algo.advantage.estimator in GROUP_ADVANTAGE_ESTIMATORS
 
         def finished_group_count() -> int:
             return len({_sample_group_key(sample) for sample in self._finished_samples})
@@ -244,7 +248,12 @@ class SamplesGenerator:
                 # Dropped groups (filtered or all-unusable) come back empty; their
                 # slot is refilled with a fresh prompt on the next iteration.
                 group_samples = self._filter_group(
-                    finished_rollout, dynamic_filtering, drop_counts, score_stats=score_stats, **generate_kwargs
+                    finished_rollout,
+                    dynamic_filtering,
+                    drop_counts,
+                    score_stats=score_stats,
+                    require_complete_group=require_complete_group,
+                    **generate_kwargs,
                 )
                 if group_samples:
                     self._finished_samples.extend(group_samples)
@@ -309,17 +318,19 @@ class SamplesGenerator:
         dynamic_filtering: bool,
         drop_counts: Dict[str, int],
         score_stats: Dict[str, float] | None = None,
+        require_complete_group: bool = False,
         **generate_kwargs,
     ) -> List[Experience]:
         """Filter one finished rollout (a prompt's N responses = one group) down to
         its kept Experiences, tallying every drop into ``drop_counts`` by reason.
 
-        The single place the keep/drop policy lives, applying both filters:
-        per-response (unusable trajectories dropped by ``_process_response_into_experience``)
-        and the group-level DAPO dynamic-reward filter. Returns ``[]`` when the
-        whole group is dropped. Both the streaming (``generate_samples``) and
-        batch/eval (``_generate_batch``) paths call it, so the per-group filter loop
-        is never reimplemented.
+        The single place the keep/drop policy lives, applying: per-response drops
+        (unusable trajectories dropped by ``_process_response_into_experience``), the
+        group-completeness check (when ``require_complete_group``), and the group-level
+        DAPO dynamic-reward filter (when ``dynamic_filtering``). Returns ``[]`` when the
+        whole group is dropped. Both the streaming (``generate_samples``) and batch/eval
+        (``_generate_batch``) paths call it, so the per-group filter loop is never
+        reimplemented.
         """
         # run_group already built each usable trajectory into a light Experience (heavy tensors
         # kept on the runner behind heavy_ref) or reported a drop reason — the controller only
@@ -331,16 +342,16 @@ class SamplesGenerator:
             elif drop_reason is not None:
                 drop_counts[drop_reason] += 1
 
-        if dynamic_filtering and group_samples:
+        if group_samples:
             # Compaction can emit several step-samples with the same terminal score. Keep one
             # representative per rollout for filtering; all segments still enter training below.
             rollout_samples = {
                 (s.rollout_ids[0] if getattr(s, "rollout_ids", None) else id(s)): s for s in group_samples
             }.values()
             # Pre-filter score stats (the model's TRUE judge pass rate over scored rollouts, BEFORE
-            # DAPO drops uniform groups). Accumulate here, before any keep/drop decision, so the
-            # logged mean reflects all-pass + all-fail + mixed (not just the kept mixed groups).
-            if score_stats is not None:
+            # any keep/drop decision), so the logged mean reflects all-pass + all-fail + mixed
+            # groups — including incomplete ones — not just the groups that survive filtering.
+            if dynamic_filtering and score_stats is not None:
                 scored = [s.scores[0].item() for s in rollout_samples if s.scores is not None]
                 if scored:
                     min_score, max_score = self.args.algo.dynamic_filtering_range
@@ -351,17 +362,19 @@ class SamplesGenerator:
                     score_stats["all_pass"] += float(gmean >= max_score)
                     score_stats["all_fail"] += float(gmean <= min_score)
             # Require COMPLETE groups: a group that lost a response to a per-response drop
-            # (vlm_truncation / no_action_tokens / logprob_misalign / ...) has < n_samples
-            # usable samples, which would pull the accepted count off train_batch_size and make
-            # it indivisible by the DP-rank count -> per-sample forward microbatches split unevenly
-            # -> NCCL collective desync/hang. Drop+backfill the whole group so each accepted group
-            # contributes exactly n_samples (batch stays a clean groups_per_batch * n_samples).
-            n_samples = generate_kwargs.get("n_samples_per_prompt", self.args.rollout.n_samples_per_prompt)
-            n_rollouts = len(rollout_samples)
-            if n_rollouts < n_samples:
-                drop_counts["incomplete_group"] += len(group_samples)
-                return []
-            if not self._passes_dynamic_filter(rollout_samples):
+            # (vlm_truncation / no_action_tokens / logprob_misalign / ...) has fewer than
+            # n_samples usable rollouts, so its advantages are computed from a partial group —
+            # changing the intended group statistics/baselines. Required when either (a) a group
+            # advantage estimator is training (the caller sets require_complete_group for
+            # grpo/dr_grpo/reinforce_baseline/rloo) or (b) dynamic filtering is on (its
+            # uniform-vs-mixed decision is itself group-based, so a partial group can flip it).
+            # Per-sample estimators without dynamic filtering, and eval, keep the partial group.
+            if require_complete_group or dynamic_filtering:
+                n_samples = generate_kwargs.get("n_samples_per_prompt", self.args.rollout.n_samples_per_prompt)
+                if len(rollout_samples) != n_samples:
+                    drop_counts["incomplete_group"] += len(group_samples)
+                    return []
+            if dynamic_filtering and not self._passes_dynamic_filter(rollout_samples):
                 drop_counts["dynamic_filter"] += len(group_samples)
                 return []
         return group_samples

--- a/tests/unit/test_samples_generator.py
+++ b/tests/unit/test_samples_generator.py
@@ -96,7 +96,7 @@ def test_generate_samples_returns_batch_as_rollouts_finish_and_keeps_pool_satura
     generator = object.__new__(SamplesGenerator)
     generator.args = SimpleNamespace(
         rollout=SimpleNamespace(batch_size=3, n_samples_per_prompt=1, vllm_generate_batch_size=5),
-        algo=SimpleNamespace(dynamic_filtering_enable=False),
+        algo=SimpleNamespace(dynamic_filtering_enable=False, advantage=SimpleNamespace(estimator="reinforce_baseline")),
         ckpt=SimpleNamespace(warm_resume_rollouts=False),
     )
     generator.prompts_dataloader = _prompt_loader(10)
@@ -120,7 +120,7 @@ def test_generate_samples_emits_short_batch_when_dataloader_exhausted(monkeypatc
     generator = object.__new__(SamplesGenerator)
     generator.args = SimpleNamespace(
         rollout=SimpleNamespace(batch_size=4, n_samples_per_prompt=1, vllm_generate_batch_size=5),
-        algo=SimpleNamespace(dynamic_filtering_enable=False),
+        algo=SimpleNamespace(dynamic_filtering_enable=False, advantage=SimpleNamespace(estimator="reinforce_baseline")),
         ckpt=SimpleNamespace(warm_resume_rollouts=False),
     )
     generator.prompts_dataloader = _prompt_loader(2)
@@ -138,7 +138,7 @@ def test_generate_samples_pool_persists_across_calls(monkeypatch):
     generator = object.__new__(SamplesGenerator)
     generator.args = SimpleNamespace(
         rollout=SimpleNamespace(batch_size=3, n_samples_per_prompt=1, vllm_generate_batch_size=5),
-        algo=SimpleNamespace(dynamic_filtering_enable=False),
+        algo=SimpleNamespace(dynamic_filtering_enable=False, advantage=SimpleNamespace(estimator="reinforce_baseline")),
         ckpt=SimpleNamespace(warm_resume_rollouts=False),
     )
     generator.prompts_dataloader = _prompt_loader(10)
@@ -168,7 +168,7 @@ def test_generator_keeps_no_checkpoint_state_and_resumes_from_dataloader(monkeyp
     generator = object.__new__(SamplesGenerator)
     generator.args = SimpleNamespace(
         rollout=SimpleNamespace(batch_size=3, n_samples_per_prompt=1, vllm_generate_batch_size=5),
-        algo=SimpleNamespace(dynamic_filtering_enable=False),
+        algo=SimpleNamespace(dynamic_filtering_enable=False, advantage=SimpleNamespace(estimator="reinforce_baseline")),
         ckpt=SimpleNamespace(warm_resume_rollouts=False),
     )
     generator.prompts_dataloader = _prompt_loader(10)
@@ -198,7 +198,11 @@ def test_generate_samples_drops_filtered_groups_and_refills_their_slots(monkeypa
     generator = object.__new__(SamplesGenerator)
     generator.args = SimpleNamespace(
         rollout=SimpleNamespace(batch_size=2, n_samples_per_prompt=1, vllm_generate_batch_size=2),
-        algo=SimpleNamespace(dynamic_filtering_enable=True, dynamic_filtering_range=(0.0, 1.0)),
+        algo=SimpleNamespace(
+            dynamic_filtering_enable=True,
+            dynamic_filtering_range=(0.0, 1.0),
+            advantage=SimpleNamespace(estimator="reinforce_baseline"),
+        ),
     )
     generator.prompts_dataloader = _prompt_loader(10)
 
@@ -240,6 +244,117 @@ def test_dynamic_filtering_counts_compaction_segments_once_per_rollout(monkeypat
 
     assert kept == samples
     assert dict(score_stats) == {"score_sum": 1.0, "score_n": 2, "groups": 1.0, "all_pass": 0.0, "all_fail": 0.0}
+
+
+def _incomplete_group(monkeypatch, n_kept=3):
+    """A group with n_kept usable rollouts where n_samples_per_prompt=4 (one lost upstream)."""
+    generator = object.__new__(SamplesGenerator)
+    generator.args = SimpleNamespace(rollout=SimpleNamespace(n_samples_per_prompt=4))
+    samples = [SimpleNamespace(rollout_ids=[rid], scores=None) for rid in ["a", "b", "c", "d"][:n_kept]]
+    monkeypatch.setattr(samples_generator.ray, "get", lambda _: [(sample, None) for sample in samples])
+    return generator, samples
+
+
+def test_incomplete_group_dropped_when_completeness_required(monkeypatch):
+    """A group that lost a rollout to a per-response drop (vlm_truncation, logprob_misalign, ...)
+    is rejected when require_complete_group is set — even with dynamic_filtering off — because a
+    partial group changes the intended group statistics/baselines for GRPO-family estimators. The
+    training caller sets require_complete_group when the estimator is in GROUP_ADVANTAGE_ESTIMATORS.
+    """
+    generator, samples = _incomplete_group(monkeypatch)
+    drop_counts = defaultdict(int)
+
+    kept = generator._filter_group(object(), False, drop_counts, require_complete_group=True)
+
+    assert kept == []
+    assert drop_counts["incomplete_group"] == 3
+
+
+def test_incomplete_group_kept_for_per_sample_estimator(monkeypatch):
+    """Per-sample estimators (gae/reinforce/on_policy_distill) score each sample independently
+    and do not need complete groups, so the caller leaves require_complete_group=False and the
+    3 usable rollouts are kept rather than discarded.
+    """
+    generator, samples = _incomplete_group(monkeypatch)
+
+    kept = generator._filter_group(object(), False, defaultdict(int), require_complete_group=False)
+
+    assert kept == samples
+
+
+def test_incomplete_group_kept_for_eval(monkeypatch):
+    """Eval (the _generate_batch path) never requests completeness: it does not compute group
+    advantages and does not backfill, so an incomplete eval group keeps its usable responses
+    instead of silently losing the whole prompt.
+    """
+    generator, samples = _incomplete_group(monkeypatch)
+
+    # Eval calls _filter_group with the default require_complete_group=False.
+    kept = generator._filter_group(object(), False, defaultdict(int))
+
+    assert kept == samples
+
+
+def test_dynamic_filtering_requires_complete_group_regardless_of_estimator(monkeypatch):
+    """Dynamic filtering is itself group-based (its uniform-vs-mixed decision depends on the whole
+    group), so an incomplete group must be dropped whenever dynamic_filtering is on — even for a
+    per-sample estimator (require_complete_group=False). Mixed scores here would otherwise PASS
+    _passes_dynamic_filter, proving the drop is for incompleteness, not uniform-score filtering.
+    """
+    generator = object.__new__(SamplesGenerator)
+    generator.args = SimpleNamespace(
+        rollout=SimpleNamespace(n_samples_per_prompt=4),
+        algo=SimpleNamespace(dynamic_filtering_range=(0.0, 1.0)),
+    )
+    # 3 mixed-score rollouts of an expected 4: mean 0.5 sits inside (0, 1) → would pass DF.
+    samples = [
+        SimpleNamespace(rollout_ids=[rid], scores=torch.tensor([score]))
+        for rid, score in [("a", 1.0), ("b", 0.5), ("c", 0.0)]
+    ]
+    monkeypatch.setattr(samples_generator.ray, "get", lambda _: [(sample, None) for sample in samples])
+    drop_counts = defaultdict(int)
+
+    kept = generator._filter_group(object(), True, drop_counts, require_complete_group=False)
+
+    assert kept == []
+    assert drop_counts["incomplete_group"] == 3
+    assert drop_counts["dynamic_filter"] == 0  # dropped for incompleteness, not the DF filter
+
+
+def test_complete_group_kept_when_completeness_required(monkeypatch):
+    """Sanity check: a full group passes the completeness check."""
+    generator = object.__new__(SamplesGenerator)
+    generator.args = SimpleNamespace(rollout=SimpleNamespace(n_samples_per_prompt=2))
+    samples = [SimpleNamespace(rollout_ids=[rid], scores=None) for rid in ["a", "b"]]
+    monkeypatch.setattr(samples_generator.ray, "get", lambda _: [(sample, None) for sample in samples])
+
+    kept = generator._filter_group(object(), False, defaultdict(int), require_complete_group=True)
+
+    assert kept == samples
+
+
+def test_score_stats_record_incomplete_scored_groups(monkeypatch):
+    """Pre-filter score stats must include an incomplete group's scores even when the group is
+    then dropped for incompleteness — the logged pre-filter score rate is defined over ALL
+    scored rollouts, so the completeness drop must not remove them from the metric.
+    """
+    generator = object.__new__(SamplesGenerator)
+    generator.args = SimpleNamespace(
+        rollout=SimpleNamespace(n_samples_per_prompt=4),
+        algo=SimpleNamespace(dynamic_filtering_range=(0.4, 0.6)),
+    )
+    # 3 scored rollouts of an expected 4 → dropped for incompleteness, but still counted.
+    samples = [SimpleNamespace(rollout_ids=[rid], scores=torch.tensor([1.0])) for rid in ["a", "b", "c"]]
+    monkeypatch.setattr(samples_generator.ray, "get", lambda _: [(sample, None) for sample in samples])
+    score_stats = defaultdict(float)
+
+    kept = generator._filter_group(
+        object(), True, defaultdict(int), score_stats=score_stats, require_complete_group=True
+    )
+
+    assert kept == []  # dropped for incompleteness
+    assert score_stats["score_n"] == 3  # but its scores were recorded first
+    assert score_stats["groups"] == 1.0
 
 
 def test_process_response_counts_only_action_tokens_for_multiturn_lengths():


### PR DESCRIPTION
## Summary
Group completeness (a group must keep all `n_samples_per_prompt` rollouts) was previously
checked only when `--algo.dynamic_filtering_enable` was set. With it unset (the default), a
group-advantage estimator (`grpo`/`dr_grpo`/`reinforce_baseline`/`rloo`) could compute
advantages from fewer than `n_samples_per_prompt` usable rollouts when a rollout was lost to
an unrelated per-response drop (`vlm_truncation`, `logprob_misalign`, `no_action_tokens`, ...),
computing advantages from a partial group and changing the intended group statistics/baselines.

Require complete groups when training with a group estimator, while preserving the existing
completeness requirement whenever dynamic filtering is on (its uniform-vs-mixed decision is
itself group-based). Per-sample estimators without dynamic filtering, and eval (`_generate_batch`,
which never backfills), retain usable partial groups. Pre-filter score-stat collection stays
before the completeness decision so incomplete-but-scored groups still count toward the logged rate.

## Test plan
- [x] `tests/unit/test_samples_generator.py`: incomplete group dropped when a group estimator
  requires it; dropped whenever dynamic filtering is on (even for a per-sample estimator, with
  mixed scores that would otherwise pass the DAPO filter); kept for a per-sample estimator with
  DF off; kept for eval; complete group kept; incomplete-but-scored group still recorded in score_stats.
- [x] Verified the two drop tests each fail against the respective pre-fix code and pass after.
- `python -m pytest -q`: 196 passed, 2 failed; both failures (`test_cp_thd_packing`) reproduce
  unchanged on `origin/main` and are unrelated to this change.