### PR TITLE
Fix AutoModel detection for Hugging Face fallback models

### DIFF
--- a/molt/trainer/fsdp/packing.py
+++ b/molt/trainer/fsdp/packing.py
@@ -61,7 +61,7 @@ def is_automodel_custom_model(model: Any) -> bool:
     for cls in type(model).__mro__:
         if getattr(cls, "_molt_automodel_custom", False):
             return True
-        if cls.__module__.startswith("nemo_automodel.components.models"):
+        if issubclass(cls, torch.nn.Module) and cls.__module__.startswith("nemo_automodel.components.models"):
             return True
     return False
 

--- a/tests/unit/test_fsdp_packing.py
+++ b/tests/unit/test_fsdp_packing.py
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import torch.nn as nn
+
+from molt.trainer.fsdp.packing import is_automodel_custom_model
+
+
+def test_hf_checkpointing_mixin_does_not_mark_hf_model_as_custom():
+    hf_mixin = type("HFCheckpointingMixin", (), {"__module__": "nemo_automodel.components.models.common"})
+    hf_model = type("Qwen3ForCausalLM", (nn.Module,), {"__module__": "transformers.models.qwen3"})
+    wrapped_model = type("Qwen3ForCausalLM", (hf_mixin, hf_model), {"__module__": hf_model.__module__})
+
+    assert not is_automodel_custom_model(wrapped_model())


### PR DESCRIPTION
# What does this PR do?

NeMo AutoModel injects a generic `HFCheckpointingMixin` into every returned model, including Hugging Face fallback models. `is_automodel_custom_model` treated any class from the `nemo_automodel.components.models` namespace as a native AutoModel implementation, so this mixin caused Hugging Face models to select AutoModel's THD packing path.

This PR requires namespace-matched classes to also subclass `torch.nn.Module`. The generic mixin is ignored, while native AutoModel model classes and the explicit `_molt_automodel_custom` marker remain supported.

A regression test covers a Hugging Face model carrying the AutoModel checkpointing mixin.

## Validation

- `python -m compileall -q molt examples/python tests`
- `python -m pytest -q`: 191 passed, 2 skipped