### PR TITLE
Fix dynamic filtering pass rate with in-flight rollouts

### DIFF
--- a/molt/trainer/rollout/samples_generator.py
+++ b/molt/trainer/rollout/samples_generator.py
@@ -213,6 +213,7 @@ class SamplesGenerator:
 
         prompts_dispatched = 0
         groups_accepted = 0
+        groups_completed = 0
         drop_counts: Dict[str, int] = defaultdict(int)
         score_stats: Dict[str, float] = defaultdict(float)  # pre-DAPO-filter score stats
         progress = tqdm(
@@ -241,6 +242,7 @@ class SamplesGenerator:
             # Take the first rollout to finish; the slow ones keep generating in vLLM.
             ready, self._inflight_rollouts = ray.wait(self._inflight_rollouts, num_returns=1)
             for finished_rollout in ready:
+                groups_completed += 1
                 # Dropped groups (filtered or all-unusable) come back empty; their
                 # slot is refilled with a fresh prompt on the next iteration.
                 group_samples = self._filter_group(
@@ -256,8 +258,8 @@ class SamplesGenerator:
         rollout_metrics = {f"rollout/dropped/{reason}": float(n) for reason, n in drop_counts.items()}
         if drop_counts:
             rollout_metrics["rollout/dropped/total"] = float(sum(drop_counts.values()))
-        if dynamic_filtering and prompts_dispatched:
-            rollout_metrics["dynamic_filtering_pass_rate"] = groups_accepted / prompts_dispatched * 100
+        if dynamic_filtering and groups_completed:
+            rollout_metrics["dynamic_filtering_pass_rate"] = groups_accepted / groups_completed * 100
         # Pre-filter stats: the model's TRUE judge pass rate over ALL scored rollouts, BEFORE DAPO
         # drops uniform groups. (post-filter `reward`/`pivotrl_correct` only covers kept MIXED groups
         # ~0.5-0.65 by construction, so it hides the real pass rate + the all-pass saturation.)

--- a/tests/unit/test_samples_generator.py
+++ b/tests/unit/test_samples_generator.py
@@ -215,7 +215,7 @@ def test_generate_samples_drops_filtered_groups_and_refills_their_slots(monkeypa
     # p1 is dropped; p2 (refilled into p1's freed slot) completes the batch.
     assert [sample.group_ids[0] for sample in samples] == ["p0", "p2"]
     assert prompts_dispatched == 4  # p0,p1 up front; p2,p3 refilled one per completion
-    assert rollout_metrics["dynamic_filtering_pass_rate"] == 2 / 4 * 100
+    assert rollout_metrics["dynamic_filtering_pass_rate"] == 2 / 3 * 100
     # The filtered group is tallied by reason for observability.
     assert rollout_metrics["rollout/dropped/dynamic_filter"] == 1.0
     assert rollout_metrics["rollout/dropped/total"] == 1.0


### PR DESCRIPTION
# What does this PR do?

`dynamic_filtering_pass_rate` divided accepted groups by all dispatched groups. Sample generation can return once the requested batch is full while speculative groups are still running. Those groups do not have a filtering result yet, so including them in the denominator makes the reported pass rate artificially low.

This PR counts groups when they complete and calculates the pass rate as accepted groups divided by completed groups.

The regression test covers two accepted groups, three completed groups, and four dispatched groups. The reported pass rate is therefore 66.7% rather than 50%.

## Validation

- `python -m compileall -q molt examples/python tests`
- `python -m pytest -q`: 190 passed, 2 skipped