### PR TITLE
Enable dynamic batching

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,7 @@ Common RL switches:
 | Compare samples per prompt | `--rollout.n_samples_per_prompt 8` plus `reinforce_baseline`, `rloo`, `grpo`, or `dr_grpo` |
 | Decouple rollout and training | `--train.async_queue_size 2` |
 | Keep rollout alive during sync | `--train.partial_rollout_enable` |
+| Dynamic token-budget batching | `--train.dynamic_batch_enable`; padded FlexAttention runs can add `--train.dynamic_batch_pad_to_multiple 1024` to reduce variable compiled shapes |
 | Filter by agent scores | `--algo.dynamic_filtering_enable --algo.dynamic_filtering_range 0.0 1.0` |
 | Correct async rollout logprobs | `--algo.advantage.is_correction_level geo` (seq-mask-tis; token-level adds `--algo.advantage.is_correction_mode clip/trunc/mask`) |
 | Freeze MoE routing (stabilize MoE RL) | `--actor.freeze_moe_router` |

--- a/molt/cli/train_rl_ray.py
+++ b/molt/cli/train_rl_ray.py
@@ -740,13 +740,25 @@ if __name__ == "__main__":
         default=False,
         help="Enable reproducible behavior during distributed training",
     )
-    # Dynamic batch changes microbatch grouping; the packed representation
-    # still follows the loaded actor model path.
+    # Dynamic batch changes microbatch grouping while preserving the model's
+    # configured packed or padded representation.
     parser.add_argument(
         "--train.dynamic_batch_enable",
         action="store_true",
         default=False,
-        help="Group packed samples by token budget; reuses the loaded model's packed forward path.",
+        help=(
+            "Group samples by length under a per-GPU token budget to improve training throughput "
+            "and avoid OOMs from variable batch lengths when the budget is set correctly."
+        ),
+    )
+    parser.add_argument(
+        "--train.dynamic_batch_pad_to_multiple",
+        type=int,
+        default=1,
+        help=(
+            "Round padded dynamic batches to this sequence-length multiple. "
+            "Use 1024 to reduce variable-shape recompilation with FlexAttention; 1 disables extra bucketing."
+        ),
     )
     parser.add_argument(
         "--train.force_on_policy",
@@ -1037,15 +1049,30 @@ if __name__ == "__main__":
             )
 
     # --- Training / rollout sizing ---
+    pad_multiple = args.train.dynamic_batch_pad_to_multiple
+    if pad_multiple < 1:
+        raise ValueError("--train.dynamic_batch_pad_to_multiple must be at least 1.")
+    if pad_multiple > 1 and not args.train.dynamic_batch_enable:
+        raise ValueError("--train.dynamic_batch_pad_to_multiple requires --train.dynamic_batch_enable.")
+    if pad_multiple > 1 and args.fsdp.packing_samples:
+        raise ValueError("--train.dynamic_batch_pad_to_multiple applies only to padded dynamic batches.")
+    cp_multiple = 2 * args.fsdp.cp_size if args.fsdp.cp_size > 1 else 1
+    if pad_multiple > 1 and pad_multiple % cp_multiple:
+        raise ValueError(
+            f"--train.dynamic_batch_pad_to_multiple must be divisible by 2 * cp_size ({cp_multiple})."
+        )
+
     if args.train.dynamic_batch_enable:
-        if not args.fsdp.packing_samples:
-            raise ValueError(
-                "--train.dynamic_batch_enable requires packed training batches; "
-                "pass --fsdp.packing_samples or disable dynamic batch."
-            )
         if args.rollout.max_tokens_per_gpu is None:
             print("[Warning] Set --rollout.max_tokens_per_gpu to --train.max_tokens_per_gpu.")
             args.rollout.max_tokens_per_gpu = args.train.max_tokens_per_gpu
+        layout = "packed" if args.fsdp.packing_samples else "padded"
+        shape_multiple = max(cp_multiple, pad_multiple) if layout == "padded" else 1
+        print(
+            f"[DynamicBatch] layout={layout}, train budget={args.train.max_tokens_per_gpu}, "
+            f"rollout budget={args.rollout.max_tokens_per_gpu} tokens/GPU, "
+            f"shape multiple={shape_multiple}."
+        )
 
     if args.train.force_on_policy and args.train.max_epochs != 1:
         raise ValueError(

--- a/molt/trainer/algorithm/experience.py
+++ b/molt/trainer/algorithm/experience.py
@@ -19,6 +19,7 @@ from typing import Any, List, Union
 
 import ray
 import torch
+import torch.nn.functional as F
 
 from molt.utils.logging_utils import init_logger
 from molt.utils.seqlen_balancing import get_seqlen_balanced_partitions
@@ -221,15 +222,23 @@ def split_experience_batch(experience: Experience) -> List[Experience]:
     return items
 
 
-def make_experience_batch(items: List[Experience]) -> Experience:
+def make_experience_batch(items: List[Experience], pad_to_multiple: int = 1) -> Experience:
     """Combine individual single-sample Experiences into a batched Experience."""
     if not items:
         raise ValueError("Empty items list")
+    if pad_to_multiple < 1:
+        raise ValueError("pad_to_multiple must be at least 1")
 
     # A rollout with no captured routing has routed_experts=None; fill it (sized to its own
     # sequence) before batching so a mix doesn't drop the batch's routing or crash on
     # None.size(-1).
     _fill_missing_routed_experts(items)
+    extra_padding = 0
+    if pad_to_multiple > 1:
+        if any(item.sequences is None for item in items):
+            raise ValueError("pad_to_multiple requires materialized sequences")
+        sequence_length = max(item.sequences.size(-1) for item in items)
+        extra_padding = -sequence_length % pad_to_multiple
 
     kwargs = {}
     for f in fields(Experience):
@@ -243,6 +252,8 @@ def make_experience_batch(items: List[Experience]) -> Experience:
                 # valid expert id and would force pad tokens to expert 0. Others pad with 0.
                 pad_value = -1 if f.name == "routed_experts" else 0
                 kwargs[f.name] = zero_pad_sequences(tensors, "right", stack=True, value=pad_value)
+                if extra_padding:
+                    kwargs[f.name] = F.pad(kwargs[f.name], (0, extra_padding), value=pad_value)
             elif Experience.is_episode_tensor_field(f.name) or first.dim() == 0:
                 kwargs[f.name] = torch.stack(tensors)
             else:

--- a/molt/trainer/algorithm/replay_buffer.py
+++ b/molt/trainer/algorithm/replay_buffer.py
@@ -16,6 +16,7 @@
 # Adapted from OpenRLHF (https://github.com/OpenRLHF/OpenRLHF),
 # Copyright (c) OpenRLHF contributors, licensed under the Apache License, Version 2.0.
 
+import math
 from typing import List
 
 import torch
@@ -58,6 +59,7 @@ class NaiveReplayBuffer:
         self.dynamic_batch = dynamic_batch
         self.dynamic_indices: List[List[int]] = []
         self.dynamic_optimizer_step: List[int] = []
+        self.pad_to_multiple = 1
 
     @torch.no_grad()
     def append(self, experience: Experience) -> None:
@@ -88,7 +90,7 @@ class NaiveReplayBuffer:
     def collate_fn(self, batch) -> Experience:
         if self.dynamic_batch:
             batch = batch[0]
-        return make_experience_batch(batch)
+        return make_experience_batch(batch, self.pad_to_multiple)
 
     def setup_dynamic_batch(self, strategy):
         args = strategy.args
@@ -121,18 +123,46 @@ class NaiveReplayBuffer:
                     f"{local_train_batch_size}-sample train batch (buffer={len(sample_lengths)})."
                 )
 
-        # split by train_batch_size, sync num_microbatches across dp
+        # Split by train_batch_size, then sync num_microbatches across DP.
         num_microbatches = []
+        padded_partitions = []
+        over_budget_indices = set()
+        if not args.fsdp.packing_samples:
+            cp_multiple = 2 * args.fsdp.cp_size if args.fsdp.cp_size > 1 else 1
+            self.pad_to_multiple = math.lcm(cp_multiple, args.train.dynamic_batch_pad_to_multiple)
+            token_budget = args.train.max_tokens_per_gpu * args.fsdp.cp_size * args.fsdp.tp_size
+
+            def padded_cost(indices):
+                max_length = max(sample_lengths[index] for index in indices)
+                aligned_max_length = (
+                    max_length + self.pad_to_multiple - 1
+                ) // self.pad_to_multiple * self.pad_to_multiple
+                return len(indices) * aligned_max_length
+
         for i in range(num_steps):
             start, end = i * local_train_batch_size, (i + 1) * local_train_batch_size
-            num_microbatches.append(
-                get_minimum_num_micro_batch_size(
-                    sample_lengths[start:end],
-                    args.train.max_tokens_per_gpu,
-                    args.fsdp.cp_size,
-                    args.fsdp.tp_size,
+            if args.fsdp.packing_samples:
+                num_microbatches.append(
+                    get_minimum_num_micro_batch_size(
+                        sample_lengths[start:end],
+                        args.train.max_tokens_per_gpu,
+                        args.fsdp.cp_size,
+                        args.fsdp.tp_size,
+                    )
                 )
-            )
+                continue
+
+            partitions = []
+            ordered_indices = sorted(range(start, end), key=lambda index: (-sample_lengths[index], index))
+            for index in ordered_indices:
+                if partitions and padded_cost(partitions[-1] + [index]) <= token_budget:
+                    partitions[-1].append(index)
+                else:
+                    partitions.append([index])
+                if padded_cost([index]) > token_budget:
+                    over_budget_indices.add(index)
+            padded_partitions.append(partitions)
+            num_microbatches.append(len(partitions))
 
         num_microbatches = torch.tensor(num_microbatches, dtype=torch.int, device=torch.cuda.current_device())
         num_microbatches = strategy.all_reduce(num_microbatches, op="max")
@@ -143,13 +173,45 @@ class NaiveReplayBuffer:
         data_partitions = []
         for i, num_mbs in enumerate(num_microbatches):
             start, end = i * local_train_batch_size, (i + 1) * local_train_batch_size
-            samples = sample_lengths[start:end]
-            partitions = get_seqlen_balanced_partitions(samples, num_mbs, equal_size=False)  # List[List[int]], index
-            for j in range(num_mbs):
-                for k in range(len(partitions[j])):
-                    partitions[j][k] += start
+            if args.fsdp.packing_samples:
+                samples = sample_lengths[start:end]
+                partitions = get_seqlen_balanced_partitions(
+                    samples, num_mbs, equal_size=False
+                )  # List[List[int]], index
+                for j in range(num_mbs):
+                    for k in range(len(partitions[j])):
+                        partitions[j][k] += start
+            else:
+                partitions = padded_partitions[i]
+                while len(partitions) < num_mbs:
+                    candidates = [j for j, partition in enumerate(partitions) if len(partition) > 1]
+                    assert candidates, f"Cannot split {end - start} samples into {num_mbs} non-empty microbatches"
+                    split_index = min(
+                        candidates,
+                        key=lambda j: (-padded_cost(partitions[j]), min(partitions[j])),
+                    )
+                    partition = partitions[split_index]
+                    midpoint = len(partition) // 2
+                    partitions[split_index : split_index + 1] = [partition[:midpoint], partition[midpoint:]]
+
+                partitions.sort(key=lambda partition: (-padded_cost(partition), min(partition)))
+                selected_indices = [index for partition in partitions for index in partition]
+                assert len(partitions) == num_mbs
+                assert all(partitions)
+                assert sorted(selected_indices) == list(range(start, end))
+                assert all(
+                    padded_cost(partition) <= token_budget
+                    or (len(partition) == 1 and partition[0] in over_budget_indices)
+                    for partition in partitions
+                )
             micro_batch_indices.extend(partitions)
             data_partitions.append(partitions)
+
+        if over_budget_indices:
+            strategy.print(
+                f"[ReplayBuffer] {len(over_budget_indices)} sample(s) exceed the padded dynamic-batch token budget "
+                "and remain singleton microbatches; they may OOM."
+            )
         self.dynamic_indices = micro_batch_indices
         self.sample_batch_size = 1
 

--- a/molt/trainer/rollout/experience_maker.py
+++ b/molt/trainer/rollout/experience_maker.py
@@ -19,6 +19,7 @@
 from __future__ import annotations
 
 import itertools
+import math
 from typing import TYPE_CHECKING, List
 
 import ray
@@ -78,10 +79,87 @@ class RemoteExperienceMaker:
         base_action_log_probs (KL recipes), old action_log_probs, and the per-token kl, ready for
         advantage estimation."""
         args = self.args
+        forward_batches = None
+        if args.train.dynamic_batch_enable and not args.fsdp.packing_samples:
+            groups = [
+                group
+                for group in (self.actor_model_group, self.initial_model_group, self.critic_model_group)
+                if group is not None
+            ]
+            actor_counts = {group.effective_actors for group in groups}
+            if len(actor_counts) != 1:
+                raise ValueError(
+                    "Padded dynamic batching requires actor, reference, and critic groups "
+                    "to have the same effective DP actor count."
+                )
+            effective_actors = actor_counts.pop()
+            if len(experiences) % effective_actors:
+                raise ValueError(
+                    f"Padded dynamic batching cannot split {len(experiences)} samples evenly across "
+                    f"{effective_actors} effective actors."
+                )
+
+            lengths = [int(experience.total_length.item()) for experience in experiences]
+            cp_multiple = 2 * args.fsdp.cp_size if args.fsdp.cp_size > 1 else 1
+            pad_to_multiple = math.lcm(cp_multiple, args.train.dynamic_batch_pad_to_multiple)
+            token_budget = args.rollout.max_tokens_per_gpu * args.fsdp.cp_size * args.fsdp.tp_size
+
+            def padded_cost(indices):
+                max_length = max(lengths[index] for index in indices)
+                aligned_length = (max_length + pad_to_multiple - 1) // pad_to_multiple * pad_to_multiple
+                return len(indices) * aligned_length
+
+            # balance_experiences already produced equal contiguous rank blocks. Bucket
+            # within each block, then equalize bucket counts so FSDP collectives align.
+            rank_partitions = []
+            over_budget = set()
+            samples_per_actor = len(experiences) // effective_actors
+            for rank in range(effective_actors):
+                start = rank * samples_per_actor
+                end = start + samples_per_actor
+                partitions = []
+                for index in sorted(range(start, end), key=lambda i: (-lengths[i], i)):
+                    if partitions and padded_cost(partitions[-1] + [index]) <= token_budget:
+                        partitions[-1].append(index)
+                    else:
+                        partitions.append([index])
+                    if padded_cost([index]) > token_budget:
+                        over_budget.add(index)
+                rank_partitions.append(partitions)
+
+            target_count = max(len(partitions) for partitions in rank_partitions)
+            forward_batches = []
+            for partitions in rank_partitions:
+                while len(partitions) < target_count:
+                    candidates = [index for index, partition in enumerate(partitions) if len(partition) > 1]
+                    split_index = min(
+                        candidates,
+                        key=lambda index: (-padded_cost(partitions[index]), min(partitions[index])),
+                    )
+                    partition = partitions[split_index]
+                    midpoint = len(partition) // 2
+                    partitions[split_index : split_index + 1] = [
+                        partition[:midpoint],
+                        partition[midpoint:],
+                    ]
+                partitions.sort(key=lambda partition: (-padded_cost(partition), min(partition)))
+                forward_batches.extend([[experiences[index] for index in partition] for partition in partitions])
+
+            if over_budget:
+                logger.warning(
+                    f"{len(over_budget)} rollout sample(s) exceed the padded dynamic-batch token budget "
+                    "and remain singleton microbatches; they may OOM."
+                )
+
         if self.critic_model_group is not None:
-            self._dispatch_forward(experiences, self.critic_model_group, "values")
+            self._dispatch_forward(experiences, self.critic_model_group, "values", forward_batches)
         if self.initial_model_group is not None:
-            self._dispatch_forward(experiences, self.initial_model_group, "base_action_log_probs")
+            self._dispatch_forward(
+                experiences,
+                self.initial_model_group,
+                "base_action_log_probs",
+                forward_batches,
+            )
 
         # Old actor log-probs. Force-on-policy with no KL reward (kl_coef==0): old == the training
         # forward, so the PPO ratio is 1 (REINFORCE) and policy_train recomputes old itself — skip
@@ -89,7 +167,7 @@ class RemoteExperienceMaker:
         # ref) run the actor forward here.
         skip_actor_old = args.train.force_on_policy and args.algo.kl.init_coef == 0
         if not skip_actor_old:
-            self._dispatch_forward(experiences, self.actor_model_group, "action_log_probs")
+            self._dispatch_forward(experiences, self.actor_model_group, "action_log_probs", forward_batches)
 
         for i, experience in enumerate(experiences):
             experience.index = [i]
@@ -118,16 +196,28 @@ class RemoteExperienceMaker:
                 experience.base_action_log_probs = None
         return experiences
 
-    def _dispatch_forward(self, experiences: List[Experience], group: "RayActorGroup", result_attr: str) -> None:
-        """Run ``group``'s forward on every sample — distributed across its DP ranks, each reloading its
-        own heavy tensors so they never reach the controller — and store the per-sample result on the
-        Experience under ``result_attr`` ("values" / "base_action_log_probs" / "action_log_probs"). Every
-        cp/tp rank in a DP group returned the same per-sample results, so keep one copy per group (drop
-        the duplicates) and flatten to one result per sample, in ``experiences`` order. Frees the
-        forward's cache before the colocated actor trains on the same GPUs."""
-        refs = group.async_run_method_batch(method_name="forward", experience=experiences)
-        outputs = list(itertools.chain.from_iterable(ray.get(refs)[:: group.duplicate_actors]))
-        for experience, output in zip(experiences, outputs):
+    def _dispatch_forward(
+        self,
+        experiences: List[Experience],
+        group: "RayActorGroup",
+        result_attr: str,
+        forward_batches=None,
+    ) -> None:
+        """Run ``group`` forwards and attach each result to its source Experience.
+
+        Padded dynamic batches remain lists of lazy samples until their worker reloads
+        and batches them. CP/TP duplicates return the same outputs, so keep one copy
+        per DP group. Free the cache before a colocated actor trains."""
+        if forward_batches is None:
+            refs = group.async_run_method_batch(method_name="forward", experience=experiences)
+            outputs = list(itertools.chain.from_iterable(ray.get(refs)[:: group.duplicate_actors]))
+            output_experiences = experiences
+        else:
+            refs = group.async_run_method_batch(method_name="forward_batch", experiences=forward_batches)
+            batch_outputs = itertools.chain.from_iterable(ray.get(refs)[:: group.duplicate_actors])
+            outputs = list(itertools.chain.from_iterable(batch_outputs))
+            output_experiences = list(itertools.chain.from_iterable(forward_batches))
+        for experience, output in zip(output_experiences, outputs):
             setattr(experience, result_attr, output)
         ray.get(group.async_run_method(method_name="empty_cache"))
 

--- a/molt/trainer/workers/actor_group.py
+++ b/molt/trainer/workers/actor_group.py
@@ -17,6 +17,7 @@
 # Copyright (c) OpenRLHF contributors, licensed under the Apache License, Version 2.0.
 
 import logging
+import math
 import os
 import socket
 from typing import Dict, Type
@@ -28,6 +29,7 @@ from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
 from tqdm import tqdm
 
 from molt.models import Actor
+from molt.trainer.algorithm.experience import make_experience_batch, split_experience_batch
 from molt.trainer.fsdp import FsdpStrategy
 from molt.trainer.placement import get_bundle_indices, ray_noset_visible_devices
 
@@ -73,6 +75,13 @@ class BaseModelActor(BaseDistributedActor):
         # configure strategy
         self.strategy = strategy
         strategy.setup_distributed()
+        args = strategy.args
+        cp_multiple = 2 * args.fsdp.cp_size if args.fsdp.cp_size > 1 else 1
+        self.dynamic_batch_pad_to_multiple = (
+            math.lcm(cp_multiple, args.train.dynamic_batch_pad_to_multiple)
+            if args.train.dynamic_batch_enable and not args.fsdp.packing_samples
+            else 1
+        )
 
     def init_model_from_pretrained(self, *args, **kwargs):
         raise NotImplementedError()
@@ -119,6 +128,20 @@ class BaseModelActor(BaseDistributedActor):
             results.append(result)
 
         return results
+
+
+def _make_forward_batch(experiences, pad_to_multiple=1):
+    rows = []
+    for experience in experiences:
+        rows.extend(split_experience_batch(experience.reload()))
+    return make_experience_batch(rows, pad_to_multiple)
+
+
+def _split_forward_batch(output, experiences):
+    return [
+        output[index : index + 1, : experience.action_mask.shape[-1]].to("cpu")
+        for index, experience in enumerate(experiences)
+    ]
 
 
 @ray.remote(num_gpus=1)
@@ -170,6 +193,24 @@ class ReferenceModelActor(BaseModelActor):
             )
         return output["action_log_probs"].to("cpu")
 
+    def forward_batch(self, experiences) -> list[torch.Tensor]:
+        batch = _make_forward_batch(experiences, self.dynamic_batch_pad_to_multiple)
+        device = torch.cuda.current_device()
+        mm_inputs = {}
+        if batch.mm_train_inputs and getattr(self.model, "is_vlm", False):
+            from molt.utils.vlm_utils import merge_mm_train_inputs
+
+            mm_inputs = merge_mm_train_inputs(batch.mm_train_inputs, device)
+
+        with torch.no_grad():
+            output = self.model(
+                batch.sequences.to(device),
+                batch.action_mask.to(device),
+                batch.attention_mask.to(device),
+                **mm_inputs,
+            )
+        return _split_forward_batch(output["action_log_probs"], experiences)
+
 
 class RayActorGroup:
     """
@@ -208,6 +249,10 @@ class RayActorGroup:
         self._num_resources_per_node = num_resources_per_node
 
         self._initiate_actors(pg, num_gpus_per_actor)
+
+    @property
+    def effective_actors(self) -> int:
+        return len(self._actor_handlers) // self.duplicate_actors
 
     def _initiate_actors(self, pg, num_gpus_per_actor):
         world_size = self._num_nodes * self._num_gpus_per_node
@@ -308,8 +353,7 @@ class RayActorGroup:
                 )
 
         # Calculate chunk size based on number of effective actors (considering ring groups)
-        num_actors = len(self._actor_handlers)
-        effective_actors = num_actors // self.duplicate_actors
+        effective_actors = self.effective_actors
         if total_length == 0 or total_length < effective_actors:
             raise ValueError(
                 f"Insufficient batch size for async_run_method_batch: total_length={total_length}, "

--- a/molt/trainer/workers/critic_actor.py
+++ b/molt/trainer/workers/critic_actor.py
@@ -50,7 +50,7 @@ from molt.utils.logging_utils import init_logger
 from molt.utils.vlm_utils import merge_mm_train_inputs
 
 from ..algorithm import NaiveReplayBuffer
-from .actor_group import BaseModelActor
+from .actor_group import BaseModelActor, _make_forward_batch, _split_forward_batch
 
 logger = init_logger(__name__)
 
@@ -350,6 +350,24 @@ class CriticModelActor(BaseModelActor):
             )
         self.critic.train()  # reset model state
         return output["action_values"].to("cpu")
+
+    def forward_batch(self, experiences) -> list[torch.Tensor]:
+        batch = _make_forward_batch(experiences, self.dynamic_batch_pad_to_multiple)
+        device = torch.cuda.current_device()
+        mm_inputs = {}
+        if batch.mm_train_inputs and getattr(self.critic, "is_vlm", False):
+            mm_inputs = merge_mm_train_inputs(batch.mm_train_inputs, device)
+
+        self.critic.eval()
+        with torch.no_grad():
+            output = self.critic(
+                batch.sequences.to(device),
+                batch.action_mask.to(device),
+                batch.attention_mask.to(device),
+                **mm_inputs,
+            )
+        self.critic.train()
+        return _split_forward_batch(output["action_values"], experiences)
 
     def append(self, experience: Experience):
         # reload() fetches the sample's heavy tensors from the producing runner's shared-memory

--- a/molt/trainer/workers/policy_actor.py
+++ b/molt/trainer/workers/policy_actor.py
@@ -41,7 +41,7 @@ from molt.utils.logging_utils import init_logger
 from molt.utils.vlm_utils import merge_mm_train_inputs
 
 from ..algorithm import NaiveReplayBuffer
-from .actor_group import BaseModelActor
+from .actor_group import BaseModelActor, _make_forward_batch, _split_forward_batch
 
 logger = init_logger(__name__)
 
@@ -891,6 +891,25 @@ class PolicyModelActor(BaseModelActor):
             )
         self.actor.train()  # reset model state
         return output["action_log_probs"].to("cpu")
+
+    def forward_batch(self, experiences) -> list[torch.Tensor]:
+        batch = _make_forward_batch(experiences, self.dynamic_batch_pad_to_multiple)
+        device = torch.cuda.current_device()
+        mm_inputs = {}
+        if batch.mm_train_inputs and getattr(self.actor, "is_vlm", False):
+            mm_inputs = merge_mm_train_inputs(batch.mm_train_inputs, device)
+
+        self.actor.eval()
+        with torch.no_grad():
+            output = self.actor(
+                batch.sequences.to(device),
+                batch.action_mask.to(device),
+                batch.attention_mask.to(device),
+                routed_experts=batch.routed_experts.to(device) if batch.routed_experts is not None else None,
+                **mm_inputs,
+            )
+        self.actor.train()
+        return _split_forward_batch(output["action_log_probs"], experiences)
 
     def broadcast_to_vllm(self):
         self.trainer.broadcast_to_vllm()

--- a/tests/unit/test_dynamic_batch.py
+++ b/tests/unit/test_dynamic_batch.py
@@ -1,0 +1,376 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from molt.trainer.algorithm.experience import Experience
+from molt.trainer.algorithm.replay_buffer import NaiveReplayBuffer
+from molt.trainer.rollout import experience_maker as experience_maker_module
+from molt.trainer.rollout.experience_maker import RemoteExperienceMaker
+from molt.trainer.workers.actor_group import _make_forward_batch, _split_forward_batch
+
+
+def _args(
+    *,
+    packing=False,
+    dynamic=True,
+    train_budget=20,
+    rollout_budget=20,
+    batch_size=1,
+    force_on_policy=False,
+    cp_size=1,
+    tp_size=1,
+    pad_multiple=1,
+):
+    return SimpleNamespace(
+        fsdp=SimpleNamespace(packing_samples=packing, cp_size=cp_size, tp_size=tp_size, ep_size=1),
+        train=SimpleNamespace(
+            dynamic_batch_enable=dynamic,
+            dynamic_batch_pad_to_multiple=pad_multiple,
+            max_tokens_per_gpu=train_budget,
+            batch_size=batch_size,
+            micro_batch_size=1,
+            force_on_policy=force_on_policy,
+        ),
+        rollout=SimpleNamespace(max_tokens_per_gpu=rollout_budget, n_samples_per_prompt=1),
+        algo=SimpleNamespace(
+            advantage=SimpleNamespace(estimator="reinforce"),
+            kl=SimpleNamespace(init_coef=1.0, use_loss=True, estimator="k1"),
+        ),
+        reward=SimpleNamespace(clip_range=None),
+    )
+
+
+def _sample(length, index, *, lazy=False):
+    return Experience(
+        sequences=None if lazy else torch.full((1, length), index + 1, dtype=torch.long),
+        attention_mask=None if lazy else torch.ones(1, length, dtype=torch.long),
+        action_mask=torch.ones(1, max(length - 1, 0), dtype=torch.bool),
+        rewards=torch.tensor([float(index)]),
+        total_length=torch.tensor([length]),
+        index=[index],
+        group_ids=[f"group-{index}"],
+        rollout_ids=[f"rollout-{index}"],
+        heavy_ref=f"ref-{index}" if lazy else None,
+    )
+
+
+class _FakeStrategy:
+    def __init__(self, args, reduced_counts=None):
+        self.args = args
+        self.reduced_counts = reduced_counts
+        self.messages = []
+
+    def all_reduce(self, values, op):
+        assert op == "max"
+        if self.reduced_counts is None:
+            return values
+        return torch.tensor(self.reduced_counts, dtype=values.dtype, device=values.device)
+
+    def print(self, message):
+        self.messages.append(message)
+
+
+def _setup_replay(monkeypatch, lengths, args, reduced_counts=None):
+    model_parallel_size = args.fsdp.cp_size * args.fsdp.tp_size
+    monkeypatch.setattr("molt.trainer.algorithm.replay_buffer.dist.get_world_size", lambda: model_parallel_size)
+    monkeypatch.setattr(
+        "molt.trainer.algorithm.replay_buffer.torch.cuda.current_device",
+        lambda: torch.device("cpu"),
+    )
+    replay = NaiveReplayBuffer(sample_batch_size=1, cpu_offload=False, dynamic_batch=True)
+    for index, length in enumerate(lengths):
+        replay.append(_sample(length, index))
+    strategy = _FakeStrategy(args, reduced_counts)
+    replay.setup_dynamic_batch(strategy)
+    return replay, strategy
+
+
+class _ForwardGroup:
+    duplicate_actors = 1
+
+    def __init__(self, effective_actors, marker):
+        self.effective_actors = effective_actors
+        self.marker = marker
+        self.calls = []
+
+    def async_run_method_batch(self, method_name, **kwargs):
+        self.calls.append((method_name, kwargs))
+        key = "experiences" if method_name == "forward_batch" else "experience"
+        items = kwargs[key]
+        chunk_size = len(items) // self.effective_actors
+        results = []
+        for rank in range(self.effective_actors):
+            chunk = items[rank * chunk_size : (rank + 1) * chunk_size]
+            if method_name == "forward_batch":
+                results.append(
+                    [
+                        [
+                            torch.full_like(experience.action_mask, self.marker, dtype=torch.float32)
+                            for experience in batch
+                        ]
+                        for batch in chunk
+                    ]
+                )
+            else:
+                results.append(
+                    [
+                        torch.full_like(experience.action_mask, self.marker, dtype=torch.float32)
+                        for experience in chunk
+                    ]
+                )
+        return results
+
+    def async_run_method(self, method_name):
+        assert method_name == "empty_cache"
+        return [None] * self.effective_actors
+
+
+def _maker(args, actor, reference=None, critic=None):
+    return RemoteExperienceMaker(
+        actor_model_group=actor,
+        initial_model_group=reference,
+        critic_model_group=critic,
+        kl_controller=None,
+        strategy=SimpleNamespace(args=args),
+        tokenizer=None,
+    )
+
+
+def test_packed_replay_partition_order_is_unchanged(monkeypatch):
+    replay, _ = _setup_replay(
+        monkeypatch,
+        [5, 3, 7, 2, 6],
+        _args(packing=True, train_budget=10, batch_size=5),
+    )
+
+    assert replay.dynamic_indices == [[3, 4], [0, 1], [2]]
+    assert replay.dynamic_optimizer_step == [0, 0, 1]
+
+
+def test_padded_replay_prices_dense_footprint_and_cp_alignment(monkeypatch):
+    padded, _ = _setup_replay(
+        monkeypatch,
+        [100, 1, 1, 1, 1],
+        _args(train_budget=104, batch_size=5),
+    )
+    packed, _ = _setup_replay(
+        monkeypatch,
+        [100, 1, 1, 1, 1],
+        _args(packing=True, train_budget=104, batch_size=5),
+    )
+    cp_aligned, _ = _setup_replay(
+        monkeypatch,
+        [5, 5],
+        _args(train_budget=7, batch_size=2, cp_size=2),
+    )
+
+    assert padded.dynamic_indices == [[0], [1, 2, 3, 4]]
+    assert packed.dynamic_indices == [[0, 1, 2, 3, 4]]
+    assert cp_aligned.dynamic_indices == [[0], [1]]
+
+
+def test_padded_replay_bucket_cost_matches_materialized_shape(monkeypatch):
+    exact, _ = _setup_replay(
+        monkeypatch,
+        [1001, 700],
+        _args(train_budget=2047, batch_size=2),
+    )
+    bucketed, _ = _setup_replay(
+        monkeypatch,
+        [1001, 700],
+        _args(train_budget=2047, batch_size=2, pad_multiple=1024),
+    )
+
+    assert exact.dynamic_indices == [[0, 1]]
+    assert bucketed.dynamic_indices == [[0], [1]]
+
+    batch = bucketed.collate_fn([[bucketed.items[index] for index in bucketed.dynamic_indices[0]]])
+    assert batch.sequences.shape == (1, 1024)
+    assert batch.attention_mask.shape == (1, 1024)
+    assert batch.action_mask.shape == (1, 1023)
+
+
+def test_padded_replay_matches_cross_rank_count_and_preserves_windows(monkeypatch):
+    replay, _ = _setup_replay(
+        monkeypatch,
+        [8, 7, 2, 1],
+        _args(train_budget=16, batch_size=4),
+        reduced_counts=[3],
+    )
+    assert replay.dynamic_indices == [[0], [1], [2, 3]]
+
+    lengths = [10, 9, 2, 1, 8, 7, 2, 1]
+    fixed, _ = _setup_replay(
+        monkeypatch,
+        lengths,
+        _args(train_budget=20, batch_size=4),
+    )
+    on_policy, _ = _setup_replay(
+        monkeypatch,
+        lengths,
+        _args(train_budget=20, batch_size=4, force_on_policy=True),
+    )
+
+    assert fixed.dynamic_indices == [[0, 1], [2, 3], [4, 5], [6, 7]]
+    assert fixed.dynamic_optimizer_step == [0, 1, 0, 1]
+    assert on_policy.dynamic_optimizer_step == [0, 0, 1]
+    assert sorted(index for batch in on_policy.dynamic_indices for index in batch) == list(range(8))
+
+
+def test_padded_replay_warns_for_over_budget_singletons(monkeypatch):
+    replay, strategy = _setup_replay(
+        monkeypatch,
+        [12, 11, 1],
+        _args(train_budget=10, batch_size=3),
+    )
+
+    assert replay.dynamic_indices == [[0], [1], [2]]
+    assert len(strategy.messages) == 1
+    assert "2 sample(s)" in strategy.messages[0]
+
+
+def test_padded_forward_schedule_is_shared_and_controller_keeps_lazy_samples(monkeypatch):
+    monkeypatch.setattr(experience_maker_module.ray, "get", lambda value: value)
+    args = _args(rollout_budget=20)
+    actor = _ForwardGroup(2, 3)
+    reference = _ForwardGroup(2, 2)
+    critic = _ForwardGroup(2, 1)
+    samples = [_sample(length, index, lazy=True) for index, length in enumerate([10, 9, 8, 7, 6, 5])]
+    refs = [sample.heavy_ref for sample in samples]
+
+    result = _maker(args, actor, reference, critic).make_experience(samples)
+
+    schedules = []
+    for group in (actor, reference, critic):
+        method_name, kwargs = group.calls[0]
+        assert method_name == "forward_batch"
+        schedules.append([[sample.index[0] for sample in batch] for batch in kwargs["experiences"]])
+    assert schedules[0] == schedules[1] == schedules[2]
+    assert schedules[0] == [[0, 1], [2], [3, 4], [5]]
+    assert sorted(index for batch in schedules[0] for index in batch) == list(range(6))
+
+    for index, experience in enumerate(result):
+        assert experience.heavy_ref == refs[index]
+        assert experience.sequences is None
+        assert experience.values.shape == experience.action_mask.shape
+        assert experience.base_action_log_probs.shape == experience.action_mask.shape
+        assert experience.action_log_probs.shape == experience.action_mask.shape
+        assert experience.values.unique().item() == 1
+        assert experience.base_action_log_probs.unique().item() == 2
+        assert experience.action_log_probs.unique().item() == 3
+
+
+@pytest.mark.parametrize(("dynamic", "packing"), [(False, False), (True, True)])
+def test_static_and_packed_forwards_remain_per_sample(monkeypatch, dynamic, packing):
+    monkeypatch.setattr(experience_maker_module.ray, "get", lambda value: value)
+    actor = _ForwardGroup(1, 3)
+    samples = [_sample(5, 0), _sample(3, 1)]
+
+    _maker(_args(dynamic=dynamic, packing=packing), actor).make_experience(samples)
+
+    method_name, kwargs = actor.calls[0]
+    assert method_name == "forward"
+    assert kwargs["experience"] == samples
+
+
+def test_padded_forward_warns_for_over_budget_singletons(monkeypatch):
+    monkeypatch.setattr(experience_maker_module.ray, "get", lambda value: value)
+    warnings = []
+    monkeypatch.setattr(experience_maker_module.logger, "warning", warnings.append)
+    actor = _ForwardGroup(1, 3)
+
+    _maker(_args(rollout_budget=10), actor).make_experience(
+        [_sample(12, 0), _sample(11, 1), _sample(1, 2)]
+    )
+
+    assert len(warnings) == 1
+    assert "2 rollout sample(s)" in warnings[0]
+
+
+def test_padded_forward_schedule_uses_shape_bucket(monkeypatch):
+    monkeypatch.setattr(experience_maker_module.ray, "get", lambda value: value)
+    actor = _ForwardGroup(1, 3)
+
+    _maker(_args(rollout_budget=2047, pad_multiple=1024), actor).make_experience(
+        [_sample(1001, 0), _sample(700, 1)]
+    )
+
+    method_name, kwargs = actor.calls[0]
+    assert method_name == "forward_batch"
+    assert [[sample.index[0] for sample in batch] for batch in kwargs["experiences"]] == [[0], [1]]
+
+
+def test_worker_batch_reload_preserves_routing_vlm_and_crops_results(monkeypatch):
+    first = _sample(4, 0)
+    second = _sample(2, 1)
+    first.routed_experts = torch.tensor([[[[1, 2, 3, 4]]]])
+    first.mm_train_inputs = [{"pixel_values": torch.ones(1, 1, 2, 2)}]
+    second.mm_train_inputs = [{"pixel_values": torch.ones(1, 1, 1, 1) * 2}]
+    first.heavy_ref = "first"
+    second.heavy_ref = "second"
+    reloaded = []
+
+    def reload(experience):
+        reloaded.append(experience.heavy_ref)
+        experience.heavy_ref = None
+        return experience
+
+    monkeypatch.setattr(Experience, "reload", reload)
+
+    batch = _make_forward_batch([first, second], pad_to_multiple=8)
+    outputs = _split_forward_batch(torch.arange(6).view(2, 3), [first, second])
+
+    assert reloaded == ["first", "second"]
+    assert batch.sequences.shape == (2, 8)
+    assert batch.action_mask.shape == (2, 7)
+    assert batch.routed_experts.shape == (2, 1, 1, 8)
+    assert batch.routed_experts[0, 0, 0].tolist() == [1, 2, 3, 4, -1, -1, -1, -1]
+    assert batch.routed_experts[1, 0, 0].tolist() == [-1] * 8
+    assert len(batch.mm_train_inputs) == 2
+    assert outputs[0].shape == (1, 3)
+    assert outputs[1].shape == (1, 1)
+    assert outputs[1].item() == 3
+
+
+@pytest.mark.skipduringci
+@pytest.mark.skipif(
+    os.environ.get("MOLT_RUN_GPU_TESTS") != "1" or not torch.cuda.is_available(),
+    reason="set MOLT_RUN_GPU_TESTS=1 on a CUDA worker",
+)
+def test_flex_attention_padding_preserves_real_outputs_and_gradients():
+    from torch.nn.attention.flex_attention import create_block_mask, flex_attention
+
+    torch.manual_seed(0)
+    device = torch.device("cuda")
+    length, padded_length = 1001, 1024
+    qkv = torch.randn(3, 1, 2, length, 64, device=device, dtype=torch.bfloat16)
+
+    def causal_mask(_batch, _head, query, key):
+        return query >= key
+
+    def run(values, sequence_length):
+        query, key, value = [tensor.detach().clone().requires_grad_() for tensor in values]
+        block_mask = create_block_mask(
+            causal_mask,
+            B=1,
+            H=2,
+            Q_LEN=sequence_length,
+            KV_LEN=sequence_length,
+            device=device,
+        )
+        output = torch.compile(flex_attention, dynamic=False)(query, key, value, block_mask=block_mask)
+        output[..., :length, :].float().sum().backward()
+        return output.detach(), [tensor.grad.detach() for tensor in (query, key, value)]
+
+    exact_output, exact_grads = run(qkv, length)
+    padded_qkv = torch.nn.functional.pad(qkv, (0, 0, 0, padded_length - length))
+    padded_output, padded_grads = run(padded_qkv, padded_length)
+
+    torch.testing.assert_close(padded_output[..., :length, :], exact_output, rtol=2e-2, atol=2e-2)
+    for padded_grad, exact_grad in zip(padded_grads, exact_grads):
+        torch.testing.assert_close(padded_grad[..., :length, :], exact_grad, rtol=2e-2, atol=2e-2)


### PR DESCRIPTION
# What does this PR do?

Padding-free packing with FA2 already solves the issue of padding + packing, but not all models support FA2 (e.g. GPT-OSS uses FlexAttention). 

With sample-based batching, the token footprint of each microbatch varies with sequence length. Thus, users often have to choose a conservatively small microbatch size so an unlucky group of long sequences doesn't OOM. This is inefficient and unreliable.

This PR enables dynamic batching. It balances sequences across data-parallel ranks, groups similar-length sequences, and constructs rank-local microbatches under `--train.max_tokens_per_gpu`. Each GPU can therefore use its available memory according to a token-level budget instead of a fixed number of samples.

Length-aware grouping spends a controlled amount of padding to replace several small forwards with fewer, larger, more GPU-efficient forwards. Each rank may use a different local padded length while executing the same number of microbatches, keeping FSDP collectives aligned.

The scheduler preserves optimizer windows, sample coverage, and global-token loss normalization. Non-singleton batches remain within the configured padded-footprint budget. A sequence that individually exceeds the budget remains a warned singleton rather than being dropped, so the configured budget must still account for the longest supported sequence and other model memory.

`--train.dynamic_batch_pad_to_multiple` controls optional shape bucketing and defaults to `1`, meaning exact padded lengths. This is dynamic microbatch sizing, not sequence packing or padding-free training.

Existing fixed microbatching and packed dynamic batching remain unchanged, and dynamic batching stays opt-in.

## GPU validation

The fixed and dynamic paths were compared on two NVIDIA B200 GPUs using frozen replay. Each arm ran in three fresh processes for 23 optimizer steps; the first three steps were excluded as warm-up.

Both arms used padded training with `--train.micro_batch_size 1`. The dynamic arm additionally used:

```text
--train.dynamic_batch_enable
--train.max_tokens_per_gpu 8192
--train.dynamic_batch_pad_to_multiple 1
```

| Model | Fixed median step | Dynamic median step | Paired speedup | Median peak-memory reduction |
| --- | ---: | ---: | ---: | ---: |
| Qwen3-4B | 3.604 s | 1.506 s | 2.36× | 14.14 GiB |
| GPT-OSS-20B Flex/MoE | 8.579 s | 5.406 s | 1.59× | 4.32 GiB |

All 12 runs consumed 184/184 samples and completed 23/23 optimizer steps without OOMs, hangs, missing samples, or collective failures.

The correctness comparisons used the same checkpoints, samples, rewards, and optimizer windows:

- Qwen3-4B produced identical policy loss, gradient cosine `0.998696`, final-weight cosine `0.999999999999`, and maximum parameter difference `3.815e-6`.
- The Qwen first-step Adam update was more sensitive to small BF16 gradient differences: update cosine `0.972842` and relative update difference `23.305%`.
- GPT-OSS-20B produced identical policy loss, update cosine `0.999956`, relative update difference `0.942%`, and maximum parameter difference `3.815e-6`.
- A direct CUDA FlexAttention test passed for valid outputs and Q/K/V gradients across exact and right-padded sequence lengths.

These results establish numerical training equivalence within expected BF16 reduction differences, not bitwise-identical gradients or updates.

## Validation

- `python -m compileall -q molt examples/python tests`
- `python -m pytest -q tests/unit/test_dynamic_batch.py`: 11 passed, 1 skipped
- `python -m pytest -q`: 202 passed, 3 skipped
- Direct CUDA FlexAttention test: 1 passed, 11 deselected

## Caveats

- Dynamic batching remains disabled by default.
- Exact-length padding (`pad_to_multiple=1`) is the recommended configuration.
- A separate 1,024-token shape-bucket experiment reduced FlexAttention recompilations but regressed median step time by 1.4%, throughput by 3.0%, and padding efficiency from 71.2% to 18.2%; it remains opt-in.
- On the longest GPT-OSS step, dynamic batching was 4.0% slower and maximum allocated memory was effectively flat (`+0.059 GiB`) because the new shape triggered a FlexAttention compile (issues with FlexAttention should be investigated deeper and addressed by a different PR)
- GPU validation covered one node, two B200 GPUs, Qwen3-4B, and GPT-OSS-20B with CP=1. Multi-node, live context-parallel, and VLM configurations were not tested.