### PR TITLE
feat(loss): add GSPO sequence-level policy-gradient surrogate

### DIFF
--- a/molt/cli/train_rl_ray.py
+++ b/molt/cli/train_rl_ray.py
@@ -524,12 +524,15 @@ if __name__ == "__main__":
         "--actor.loss_mode",
         type=str,
         default="ppo",
-        choices=["ppo", "cispo"],
+        choices=["ppo", "cispo", "gspo"],
         help="Policy-gradient surrogate: ppo (clipped min(surr1,surr2), optionally --actor.dual_clip) or "
         "cispo (https://arxiv.org/abs/2506.13585 — clips only the upper side of the IS ratio, "
         "stop-gradient through that weight, gradient flows through log-probs only; pass "
         "--actor.eps_clip_low_high's high value as the absolute ratio ceiling, e.g. 1.2, not a +offset; "
-        "--actor.dual_clip is unused in this mode).",
+        "--actor.dual_clip is unused in this mode) or "
+        "gspo (https://arxiv.org/abs/2507.18071 — clips ONE ratio per sequence, its geometric mean, "
+        "so a single outlier token cannot clip the whole update; pair with "
+        "--actor.loss_agg_mode seq-mean-token-mean; --actor.dual_clip is unused in this mode).",
     )
     parser.add_argument(
         "--actor.entropy_coef",

--- a/molt/models/loss.py
+++ b/molt/models/loss.py
@@ -218,6 +218,28 @@ def ppo_policy_loss(ratio, advantages, log_probs, action_mask, *, clip_eps_low, 
     return loss, clip_ratio
 
 
+@register_policy_loss("gspo")
+def gspo_policy_loss(ratio, advantages, log_probs, action_mask, *, clip_eps_low, clip_eps_high, policy_log_ratio, **_):
+    """GSPO (https://arxiv.org/abs/2507.18071): clip one IS ratio per SEQUENCE, not per token.
+
+    The ratio is the sequence's geometric mean `s = exp(mean_t log(pi/pi_old))`, so a single
+    outlier token can no longer clip (or blow up) the whole update -- the failure mode PPO's
+    per-token ratio has on long MoE rollouts. Gradient still flows per token via the identity
+    `log s_t = sg[log s] + log_prob - sg[log_prob]`, which is numerically `log s` but carries
+    each token's own gradient (GSPO-token in the paper). Recommended with
+    `--actor.loss_agg_mode seq-mean-token-mean`, the aggregation the objective is defined over.
+    """
+    # `policy_log_ratio` is forward's already-clamped log-ratio, so `s` inherits the same
+    # +-log_ratio_limit bound (a mean of bounded terms) and needs no clamp of its own.
+    seq_log_ratio = masked_mean(policy_log_ratio, action_mask, dim=-1).detach().unsqueeze(-1)
+    seq_ratio = (log_probs - log_probs.detach() + seq_log_ratio).exp()
+    surr1 = seq_ratio * advantages
+    surr2 = seq_ratio.clamp(1 - clip_eps_low, 1 + clip_eps_high) * advantages
+    loss = -torch.min(surr1, surr2)
+    clip_ratio = masked_mean(torch.lt(surr2, surr1).float(), action_mask, dim=None)
+    return loss, clip_ratio
+
+
 @register_policy_loss("cispo")
 def cispo_policy_loss(ratio, advantages, log_probs, action_mask, *, clip_eps_high, **_):
     """CISPO (https://arxiv.org/abs/2506.13585): stop-gradient upper-clipped IS weight,
@@ -278,10 +300,12 @@ class PolicyLoss(nn.Module):
             # CISPO clamps the raw ratio to an absolute ceiling (not a +offset like PPO's
             # surr2), so clip_eps_high here must be passed as that ceiling (e.g. 1.2).
             assert clip_eps_high >= 1.0, f"clip_eps_high must be >= 1.0 if loss_mode='cispo', got {clip_eps_high}"
-            # dual_clip only has meaning for the min(surr1, surr2) PPO surrogate CISPO
-            # doesn't compute; reject rather than silently ignore it.
-            if dual_clip is not None:
-                raise ValueError("dual_clip is a PPO-only extra bound; it has no effect under loss_mode='cispo'")
+        # dual_clip is an extra bound on PPO's min(surr1, surr2); the other surrogates do not
+        # compute that min, so reject it rather than silently ignore it.
+        if dual_clip is not None and self.loss_mode != "ppo":
+            raise ValueError(
+                f"dual_clip is a PPO-only extra bound; it has no effect under loss_mode={self.loss_mode!r}"
+            )
 
         if self.is_correction_level not in {"off", "token", "seq", "geo"}:
             raise ValueError(f"is_correction_level must be off/token/seq/geo, got {self.is_correction_level}")
@@ -330,6 +354,7 @@ class PolicyLoss(nn.Module):
             clip_eps_low=self.clip_eps_low,
             clip_eps_high=self.clip_eps_high,
             dual_clip=self.dual_clip,
+            policy_log_ratio=policy_log_ratio,
         )
 
         vllm_kl = None

--- a/tests/unit/test_policy_loss.py
+++ b/tests/unit/test_policy_loss.py
@@ -340,10 +340,82 @@ def test_compute_approx_kl_sanitizes_equal_negative_infinity_logprobs():
 def test_policy_loss_registry_rejects_unknown_and_duplicate_names():
     from molt.models.loss import POLICY_LOSSES, get_policy_loss, register_policy_loss
 
-    assert {"ppo", "cispo"} <= set(POLICY_LOSSES)  # built-in surrogates are registered
+    assert {"ppo", "cispo", "gspo"} <= set(POLICY_LOSSES)  # built-in surrogates are registered
     with pytest.raises(ValueError, match="Unknown policy loss"):
         get_policy_loss("nope")
     with pytest.raises(ValueError, match="Unknown policy loss"):
         PolicyLoss(loss_mode="nope")  # surfaced at construction
     with pytest.raises(ValueError, match="already registered"):
         register_policy_loss("ppo")(lambda *a, **k: None)  # no silent shadowing
+
+
+def test_gspo_scores_every_token_with_the_sequence_geometric_mean_ratio():
+    # log-ratios [0.3, -0.1] -> geometric mean exp(mean) = exp(0.1), inside the [0.8, 1.2]
+    # clip band, so both tokens are weighted by that single sequence ratio.
+    loss_fn = PolicyLoss(loss_mode="gspo")
+    log_probs = torch.tensor([[0.3, -0.1]])
+
+    loss, *_ = loss_fn(
+        log_probs,
+        torch.zeros(1, 2),
+        torch.ones(1, 2),
+        action_mask=torch.ones(1, 2, dtype=torch.bool),
+    )
+
+    torch.testing.assert_close(loss, -torch.tensor(0.1).exp())
+
+
+def test_gspo_does_not_clip_when_only_individual_tokens_are_off_policy():
+    # The defining GSPO property. Per-token ratios exp(+-1) = [2.72, 0.37] are both far
+    # outside [0.8, 1.2], so PPO clips every token; the sequence geometric mean is exp(0)
+    # = 1.0, so GSPO clips nothing.
+    log_probs = torch.tensor([[1.0, -1.0]])
+    args = (log_probs, torch.zeros(1, 2), torch.ones(1, 2))
+    mask = torch.ones(1, 2, dtype=torch.bool)
+
+    gspo_loss, _, gspo_clip, *_ = PolicyLoss(loss_mode="gspo")(*args, action_mask=mask)
+    ppo_loss, _, ppo_clip, *_ = PolicyLoss(loss_mode="ppo")(*args, action_mask=mask)
+
+    torch.testing.assert_close(gspo_loss, torch.tensor(-1.0))
+    torch.testing.assert_close(gspo_clip, torch.tensor(0.0))
+    # PPO keeps the clipped 1.2 on one token and the raw 0.37 on the other.
+    torch.testing.assert_close(ppo_loss, -(torch.tensor(1.2) + torch.tensor(-1.0).exp()) / 2.0)
+    torch.testing.assert_close(ppo_clip, torch.tensor(0.5))
+
+
+def test_gspo_padding_never_enters_the_sequence_ratio():
+    # A masked-out token with a huge log-ratio must not move the geometric mean; only the
+    # single valid token (log-ratio 0.1, inside the clip band) may set it.
+    loss_fn = PolicyLoss(loss_mode="gspo")
+
+    loss, *_ = loss_fn(
+        torch.tensor([[0.1, 5.0]]),
+        torch.zeros(1, 2),
+        torch.ones(1, 2),
+        action_mask=torch.tensor([[1, 0]], dtype=torch.bool),
+    )
+
+    torch.testing.assert_close(loss, -torch.tensor(0.1).exp())
+
+
+def test_gspo_gradient_reaches_each_token_through_its_own_log_prob():
+    # log s_t = sg[log s] + log_prob_t - sg[log_prob_t] is numerically log s, so the ratio is
+    # shared, but d(loss)/d(log_prob_t) = -A * s / N stays per token -- no token is starved.
+    loss_fn = PolicyLoss(loss_mode="gspo")
+    log_probs = torch.tensor([[0.3, -0.1]], requires_grad=True)
+
+    loss, *_ = loss_fn(
+        log_probs,
+        torch.zeros(1, 2),
+        torch.ones(1, 2),
+        action_mask=torch.ones(1, 2, dtype=torch.bool),
+    )
+    loss.backward()
+
+    expected = -torch.tensor(0.1).exp() / 2.0
+    torch.testing.assert_close(log_probs.grad, expected.expand(1, 2).contiguous())
+
+
+def test_gspo_rejects_dual_clip():
+    with pytest.raises(ValueError, match="dual_clip is a PPO-only extra bound"):
+        PolicyLoss(loss_mode="gspo", dual_clip=3.0)


### PR DESCRIPTION
The policy-loss registry note in `loss.py` uses `@register_policy_loss("gspo")` as its
example, so this fills that in.

GSPO (https://arxiv.org/abs/2507.18071) clips one importance ratio per sequence — the
sequence geometric mean — instead of one per token. A single off-policy token can no
longer clip or blow up the whole update, which is the failure mode PPO's per-token ratio
hits on long MoE rollouts. It uses the GSPO-token form (`log s_t = sg[log s] + log_prob -
sg[log_prob]`), numerically equal to `log s` but keeping a per-token gradient, so it drops
into the existing per-token `forward` unchanged. Pair it with
`--actor.loss_agg_mode seq-mean-token-mean`, the aggregation the objective is defined over.

Changes:
- `gspo` surrogate in the registry (no change to `PolicyLoss.forward` beyond passing the
  already-clamped `policy_log_ratio` it needs).
- `dual_clip` rejection generalized from cispo-only to "any non-ppo mode" — it only bounds
  PPO's `min(surr1, surr2)`, which the other surrogates don't compute.
- `--actor.loss_mode` gains `gspo` with help text.

Tests (5 added): the geometric-mean weighting, the defining property (per-token ratios far
outside the clip band while the sequence ratio stays 1.0 → PPO clips, GSPO does not),
padding never entering the sequence ratio, per-token gradient flow, and dual_clip rejection.

Draft for now — happy to adjust naming/scope. Local: `pytest` 198 passed, pre-commit clean.