### PR TITLE
docs(loss): correct the gspo log-ratio comment and the registry example

### DIFF
--- a/molt/models/loss.py
+++ b/molt/models/loss.py
@@ -179,7 +179,7 @@ class ValueLoss(nn.Module):
 # A surrogate maps the per-token IS ``ratio`` + advantages to a per-token loss and the
 # clip-fraction metric; PolicyLoss.forward owns everything shared (ratio, IS correction,
 # aggregation). Register a new surrogate the same way advantage estimators register, so it
-# plugs in without editing forward:  @register_policy_loss("gspo") def ...(...).
+# plugs in without editing forward:  @register_policy_loss("my_surrogate") def ...(...).
 PolicyLossFn = Callable[..., Tuple[torch.Tensor, torch.Tensor]]
 POLICY_LOSSES: Dict[str, PolicyLossFn] = {}
 
@@ -229,8 +229,10 @@ def gspo_policy_loss(ratio, advantages, log_probs, action_mask, *, clip_eps_low,
     each token's own gradient (GSPO-token in the paper). Recommended with
     `--actor.loss_agg_mode seq-mean-token-mean`, the aggregation the objective is defined over.
     """
-    # `policy_log_ratio` is forward's already-clamped log-ratio, so `s` inherits the same
-    # +-log_ratio_limit bound (a mean of bounded terms) and needs no clamp of its own.
+    # `policy_log_ratio` is forward's sanitized log-ratio (nan/+-inf mapped to finite values,
+    # padding zeroed); the masked mean keeps padding out of `s`. Unlike PPO's `ratio` it is not
+    # clamped: a finite per-token log-ratio anywhere near +-log_ratio_limit already means a
+    # broken run, and averaging is far more robust to one outlier than a per-token ratio is.
     seq_log_ratio = masked_mean(policy_log_ratio, action_mask, dim=-1).detach().unsqueeze(-1)
     seq_ratio = (log_probs - log_probs.detach() + seq_log_ratio).exp()
     surr1 = seq_ratio * advantages


### PR DESCRIPTION
Follow-up to the review nit on #53 — comments only, no behavior change.

`policy_log_ratio` is `nan_to_num`-ed and mask-zeroed in `forward`, but the
`.clamp(±log_ratio_limit)` on the next line builds the `ratio` tensor and does not
write back, so my "already-clamped … needs no clamp of its own" overstated the
bound: it holds for infinite inputs, not for finite log-ratios above the limit. The
new comment states what `forward` actually guarantees and why a clamp is still not
wanted here (a finite per-token log-ratio that large already means a broken run, and
an average is far more robust to one outlier than a per-token ratio).

Not adding a clamp on purpose — it cannot trigger under the shipped recipes, and
`is_log_ratio` below shows the codebase clamps explicitly where it wants the bound.

Second hunk: the registry note used `@register_policy_loss("gspo")` as its
how-to-add-one example, which now reads as if `gspo` were still hypothetical when it
is defined a few lines below. Switched to a placeholder name.