### PR TITLE
Enable Liger layers

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,6 +411,16 @@ Quick-start single-node usage:
 MODEL_PATH=/path/to/Qwen3-4B bash examples/scripts/quick_start/rl_qwen3_4b.sh
 ```
 
+Dense text Qwen3-4B can optionally use Liger layer kernels. Install the pinned
+extra, then add `--fsdp.use_liger_kernel` to the Qwen3-4B SFT or RL CLI command:
+
+```bash
+pip install -e '.[liger]'
+```
+
+This switch supports only the HF backend with TP, CP, and EP sizes of one. It
+does not enable a fused policy or language-model-head loss.
+
 The geo3k VLM scripts (`rl_qwen3_6_35b.sh` / `sft_qwen3_6_35b.sh`) auto-prepare the
 dataset on first run via `examples/python/utils/prepare_geo3k.py`. To pre-stage it
 manually (or refresh it), run:

--- a/README.md
+++ b/README.md
@@ -418,8 +418,10 @@ extra, then add `--fsdp.use_liger_kernel` to the Qwen3-4B SFT or RL CLI command:
 pip install -e '.[liger]'
 ```
 
-This switch supports only the HF backend with TP, CP, and EP sizes of one. It
-does not enable a fused policy or language-model-head loss.
+This switch supports native or HF dense text Qwen3 with TP, CP, and EP sizes
+of one, including padded and TE packed batches. It replaces only MLP and
+RMSNorm layers; attention, RoPE, and the policy/language-model-head loss stay
+on Molt's regular path.
 
 The geo3k VLM scripts (`rl_qwen3_6_35b.sh` / `sft_qwen3_6_35b.sh`) auto-prepare the
 dataset on first run via `examples/python/utils/prepare_geo3k.py`. To pre-stage it

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -120,6 +120,7 @@ repository.
 | grpcio | Apache-2.0 | https://github.com/grpc/grpc |
 | huggingface_hub | Apache-2.0 | https://github.com/huggingface/huggingface_hub |
 | jsonlines | BSD-3-Clause | https://github.com/wbolster/jsonlines |
+| liger-kernel (extra) | BSD-2-Clause | https://github.com/linkedin/Liger-Kernel |
 | nemo-automodel | Apache-2.0 | https://github.com/NVIDIA-NeMo/Automodel |
 | optree | Apache-2.0 | https://github.com/metaopt/optree |
 | packaging | Apache-2.0 OR BSD-2-Clause | https://github.com/pypa/packaging |

--- a/docs/liger-kernel-validation.md
+++ b/docs/liger-kernel-validation.md
@@ -1,0 +1,40 @@
+# Liger Qwen3 validation
+
+`--fsdp.use_liger_kernel` is an opt-in for dense text Qwen3. It patches only
+Qwen3 MLP and RMSNorm modules; it does not change attention, RoPE, packing
+semantics, or the policy/language-model-head loss.
+
+Run the correctness suite through pytest under `torchrun`; executing the test
+file directly only defines tests and does not run assertions.
+
+```bash
+torchrun --standalone --nproc-per-node=1 -m pytest -q tests/gpu/test_liger_qwen3.py
+torchrun --standalone --nproc-per-node=2 -m pytest -q tests/gpu/test_liger_qwen3.py
+```
+
+The suite compares native AutoModel baseline and Liger runs for padded BSHD and
+TE-packed THD Qwen3. It checks logits, action log-probabilities, entropy,
+policy loss, finite gradients, and one AdamW update; the two-rank case also
+checks the FSDP-reduced loss.
+
+Performance results are only meaningful after the correctness suite passes.
+For each layout, collect five independent baseline and Liger runs with the
+same model, GPU count, sequence-length distribution, optimizer, warmups, and
+measured steps. Report median step time, tokens per second, and peak allocated
+and reserved memory for each arm, plus the raw measurements. Claim an
+improvement only when Liger is at least 5% better and a bootstrap confidence
+interval excludes no improvement; otherwise report the result without a
+performance claim.
+
+Use the tracked harness to produce one raw JSON file per arm and repetition:
+
+```bash
+torchrun --standalone --nproc-per-node=2 tests/gpu/benchmark_liger_qwen3.py \
+  --model /path/to/Qwen3 --output results/padded-baseline-1.json
+torchrun --standalone --nproc-per-node=2 tests/gpu/benchmark_liger_qwen3.py \
+  --model /path/to/Qwen3 --use-liger-kernel --output results/padded-liger-1.json
+torchrun --standalone --nproc-per-node=2 tests/gpu/benchmark_liger_qwen3.py \
+  --model /path/to/Qwen3 --packing-samples --output results/packed-baseline-1.json
+torchrun --standalone --nproc-per-node=2 tests/gpu/benchmark_liger_qwen3.py \
+  --model /path/to/Qwen3 --packing-samples --use-liger-kernel --output results/packed-liger-1.json
+```

--- a/molt/cli/common_args.py
+++ b/molt/cli/common_args.py
@@ -61,6 +61,12 @@ def add_fsdp_args(parser) -> None:
         help="Attention implementation (e.g., sdpa, eager, flex, te, flash_attention_2)",
     )
     parser.add_argument("--fsdp.packing_samples", action="store_true", default=False)
+    parser.add_argument(
+        "--fsdp.use_liger_kernel",
+        action="store_true",
+        default=False,
+        help="Enable Liger layer kernels for dense text HF Qwen3; TP/CP/EP/VLM and fused loss are not enabled.",
+    )
 
 
 def add_ckpt_args(parser, default_ckpt_path: str) -> None:

--- a/molt/cli/common_args.py
+++ b/molt/cli/common_args.py
@@ -65,7 +65,7 @@ def add_fsdp_args(parser) -> None:
         "--fsdp.use_liger_kernel",
         action="store_true",
         default=False,
-        help="Enable Liger layer kernels for dense text HF Qwen3; TP/CP/EP/VLM and fused loss are not enabled.",
+        help="Enable Liger MLP/RMSNorm kernels for dense text Qwen3; TP/CP/EP/VLM and fused loss are not enabled.",
     )
 
 

--- a/molt/cli/train_sft.py
+++ b/molt/cli/train_sft.py
@@ -41,6 +41,7 @@ def train(args):
         moe_config=strategy.moe_config,
         activation_checkpointing=args.model.gradient_checkpoint,
         packing_samples=args.fsdp.packing_samples,
+        use_liger_kernel=args.fsdp.use_liger_kernel,
         freeze_visual_encoder=args.model.freeze_visual_encoder,
         moe_aux_loss_coef=args.model.aux_loss_coef,
     )

--- a/molt/models/base.py
+++ b/molt/models/base.py
@@ -322,11 +322,6 @@ class BaseModel(nn.Module):
         if is_moe and not ep_active:
             raise ValueError("MoE models require --fsdp.ep_size > 1 in the AutoModel custom-only branch.")
         use_hf_model = _will_use_hf_model(pretrain_or_model)
-        if use_liger_kernel and not use_hf_model:
-            raise RuntimeError(
-                "--fsdp.use_liger_kernel supports the HuggingFace fallback for dense text Qwen3 only; "
-                "AutoModel predicts a native backend for this checkpoint."
-            )
         # EP dispatch is a nemo_automodel custom-path feature; HF has no equivalent. An
         # HF-fallback model under active EP would silently mis-shard experts / train on
         # wrong grads, so forbid it loudly. (TP/CP run on HF, so they aren't gated here.)
@@ -448,7 +443,9 @@ class BaseModel(nn.Module):
             torch_dtype=torch_dtype,
             attn_implementation=attn_for_from_pretrained,
             distributed_setup=dist_setup,
-            use_liger_kernel=use_liger_kernel,
+            # Patch the loaded instance below. AutoModel's built-in option only patches
+            # its HF fallback, while the native Qwen3 modules are the intended path.
+            use_liger_kernel=False,
             has_packed_sequence=packing_samples,
             force_hf=False,
             # Disable the MTP head via AutoModel's config-override deep-merge (see
@@ -461,18 +458,32 @@ class BaseModel(nn.Module):
         # re-derive from the loaded class so the forward picks the right pack style.
         self._packing_style = "automodel" if is_automodel_custom_model(self.model) else "hf"
         if use_liger_kernel:
-            has_liger_forward = any(
-                getattr(getattr(module, "forward", None), "__module__", "").startswith("liger_kernel.")
-                for module in self.model.modules()
+            if getattr(getattr(self.model, "config", None), "model_type", None) != "qwen3":
+                raise ValueError("--fsdp.use_liger_kernel supports dense text Qwen3 only.")
+            from liger_kernel.transformers.monkey_patch import apply_liger_kernel_to_qwen3
+
+            # Keep Molt's attention, RoPE, and policy-loss paths intact. Liger replaces
+            # only the Qwen3 MLP and RMSNorm module forwards on this model instance.
+            apply_liger_kernel_to_qwen3(
+                rope=False,
+                cross_entropy=False,
+                fused_linear_cross_entropy=False,
+                model=self.model,
             )
-            if self._packing_style != "hf" or not has_liger_forward:
+            qwen3_layers = [
+                module
+                for name, module in self.model.named_modules()
+                if name in {"norm", "model.norm"}
+                or name.endswith((".mlp", ".input_layernorm", ".post_attention_layernorm"))
+            ]
+            if not qwen3_layers or not all(
+                getattr(module.forward, "__module__", "").startswith("liger_kernel.") for module in qwen3_layers
+            ):
                 raise RuntimeError(
-                    "--fsdp.use_liger_kernel was requested, but AutoModel returned a model without observable "
-                    "Liger patch evidence. Use a supported dense text HF Qwen3 checkpoint and verify the pinned "
-                    "liger dependency is installed."
+                    "--fsdp.use_liger_kernel was requested, but Liger did not patch every Qwen3 MLP and RMSNorm."
                 )
             if not torch.distributed.is_initialized() or torch.distributed.get_rank() == 0:
-                print("[Liger] enabled on HF backend.")
+                print(f"[Liger] enabled on {self._packing_style} Qwen3 backend.")
         configure_nemo_moe_aux_loss(self.model, moe_aux_loss_coef)
         if routing_replay:
             # R3: give every MoE gate a RouterReplay handle so the training forward

--- a/molt/models/base.py
+++ b/molt/models/base.py
@@ -254,6 +254,7 @@ class BaseModel(nn.Module):
         moe_config=None,
         activation_checkpointing: Union[bool, str] = False,
         packing_samples: bool = False,
+        use_liger_kernel: bool = False,
         temperature: float = 1.0,
         freeze_visual_encoder: bool = False,
         freeze_moe_router: bool = False,
@@ -273,6 +274,11 @@ class BaseModel(nn.Module):
         cp_mesh = device_mesh["cp"] if device_mesh is not None and "cp" in mesh_dims else None
         self.cp_size = cp_mesh.size() if cp_mesh is not None else 1
 
+        if use_liger_kernel and not isinstance(pretrain_or_model, str):
+            raise ValueError(
+                "--fsdp.use_liger_kernel requires loading a model path through AutoModel; "
+                "a pre-instantiated model has already bypassed the Liger patch point."
+            )
         if not isinstance(pretrain_or_model, str):
             self.model = pretrain_or_model
             self.is_vlm = False
@@ -295,15 +301,32 @@ class BaseModel(nn.Module):
 
         from molt.utils.utils import convert_to_torch_dtype, is_vlm_model
 
+        ep_active = moe_mesh is not None
+        if use_liger_kernel:
+            if find_spec("liger_kernel") is None:
+                raise RuntimeError(
+                    "--fsdp.use_liger_kernel requires the optional dependency; install it with "
+                    "`pip install -e '.[liger]'`."
+                )
+            tp_size = device_mesh["tp"].size() if device_mesh is not None and "tp" in mesh_dims else 1
+            if tp_size > 1 or self.cp_size > 1 or ep_active:
+                raise ValueError("--fsdp.use_liger_kernel requires --fsdp.tp_size=--fsdp.cp_size=--fsdp.ep_size=1.")
+            if getattr(distributed_config, "sequence_parallel", False):
+                raise ValueError("--fsdp.use_liger_kernel does not support --fsdp.sequence_parallel.")
+
         # Trainable actors keep fp32 master weights unless the architecture
         # requires compute-dtype parameters. FSDP2 handles bf16 fwd/bwd via
         # MixedPrecisionPolicy.
         compute_dtype = convert_to_torch_dtype(param_dtype)
         is_moe = _detect_moe_arch(pretrain_or_model)
-        ep_active = moe_mesh is not None
         if is_moe and not ep_active:
             raise ValueError("MoE models require --fsdp.ep_size > 1 in the AutoModel custom-only branch.")
         use_hf_model = _will_use_hf_model(pretrain_or_model)
+        if use_liger_kernel and not use_hf_model:
+            raise RuntimeError(
+                "--fsdp.use_liger_kernel supports the HuggingFace fallback for dense text Qwen3 only; "
+                "AutoModel predicts a native backend for this checkpoint."
+            )
         # EP dispatch is a nemo_automodel custom-path feature; HF has no equivalent. An
         # HF-fallback model under active EP would silently mis-shard experts / train on
         # wrong grads, so forbid it loudly. (TP/CP run on HF, so they aren't gated here.)
@@ -336,7 +359,8 @@ class BaseModel(nn.Module):
         # rounds away AdamW updates (~LR < bf16 ULP) at small LR, so the MoE never learns.
         torch_dtype = compute_dtype if not use_fp32_master_weights else torch.float32
         self.is_vlm = is_vlm_model(pretrain_or_model)
-
+        if use_liger_kernel and self.is_vlm:
+            raise ValueError("--fsdp.use_liger_kernel supports text-only Qwen3; VLM models are not enabled.")
         if self.is_vlm:
             from nemo_automodel import NeMoAutoModelForImageTextToText as ModelCls
         else:
@@ -424,7 +448,7 @@ class BaseModel(nn.Module):
             torch_dtype=torch_dtype,
             attn_implementation=attn_for_from_pretrained,
             distributed_setup=dist_setup,
-            use_liger_kernel=False,
+            use_liger_kernel=use_liger_kernel,
             has_packed_sequence=packing_samples,
             force_hf=False,
             # Disable the MTP head via AutoModel's config-override deep-merge (see
@@ -436,6 +460,19 @@ class BaseModel(nn.Module):
         # from_pretrained may downgrade to HF even when custom was requested;
         # re-derive from the loaded class so the forward picks the right pack style.
         self._packing_style = "automodel" if is_automodel_custom_model(self.model) else "hf"
+        if use_liger_kernel:
+            has_liger_forward = any(
+                getattr(getattr(module, "forward", None), "__module__", "").startswith("liger_kernel.")
+                for module in self.model.modules()
+            )
+            if self._packing_style != "hf" or not has_liger_forward:
+                raise RuntimeError(
+                    "--fsdp.use_liger_kernel was requested, but AutoModel returned a model without observable "
+                    "Liger patch evidence. Use a supported dense text HF Qwen3 checkpoint and verify the pinned "
+                    "liger dependency is installed."
+                )
+            if not torch.distributed.is_initialized() or torch.distributed.get_rank() == 0:
+                print("[Liger] enabled on HF backend.")
         configure_nemo_moe_aux_loss(self.model, moe_aux_loss_coef)
         if routing_replay:
             # R3: give every MoE gate a RouterReplay handle so the training forward

--- a/molt/trainer/workers/actor_group.py
+++ b/molt/trainer/workers/actor_group.py
@@ -135,6 +135,7 @@ class ReferenceModelActor(BaseModelActor):
             moe_config=strategy.moe_config,
             activation_checkpointing=False,
             packing_samples=strategy.args.fsdp.packing_samples,
+            use_liger_kernel=strategy.args.fsdp.use_liger_kernel,
             temperature=strategy.args.rollout.temperature,
             # Keep reference numerics on the same AutoModel path as the
             # trainable actor. Custom AutoModel Llama is not fp32/bf16 forward

--- a/molt/trainer/workers/critic_actor.py
+++ b/molt/trainer/workers/critic_actor.py
@@ -268,6 +268,7 @@ class CriticModelActor(BaseModelActor):
             moe_config=strategy.moe_config,
             activation_checkpointing=args.actor.gradient_checkpoint,
             packing_samples=args.fsdp.packing_samples,
+            use_liger_kernel=args.fsdp.use_liger_kernel,
             temperature=args.rollout.temperature,
             freeze_visual_encoder=getattr(args.actor, "freeze_visual_encoder", False),
             # Critic router freeze: its own --critic.freeze_moe_router, or inherit the actor's flag.

--- a/molt/trainer/workers/policy_actor.py
+++ b/molt/trainer/workers/policy_actor.py
@@ -766,6 +766,7 @@ class PolicyModelActor(BaseModelActor):
             moe_config=strategy.moe_config,
             activation_checkpointing=args.actor.gradient_checkpoint,
             packing_samples=strategy.args.fsdp.packing_samples,
+            use_liger_kernel=strategy.args.fsdp.use_liger_kernel,
             temperature=strategy.args.rollout.temperature,
             freeze_visual_encoder=getattr(strategy.args.actor, "freeze_visual_encoder", False),
             freeze_moe_router=getattr(strategy.args.actor, "freeze_moe_router", False),

--- a/setup.py
+++ b/setup.py
@@ -99,6 +99,9 @@ setup(
         "vllm": ["vllm==0.25.1"],
         "vllm_latest": ["vllm>=0.24.0"],
         "flash-attn-2": ["flash-attn==2.8.3"],
+        "liger": [
+            "liger-kernel @ git+https://github.com/linkedin/Liger-Kernel.git@1f1a4b8d6a6c3c1ddb3573a46480c41cef25bde6"
+        ],
     },
     python_requires=">=3.10",
     classifiers=[

--- a/tests/gpu/test_liger_qwen3.py
+++ b/tests/gpu/test_liger_qwen3.py
@@ -1,0 +1,209 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.distributed as dist
+
+pytest.importorskip("flash_attn")
+pytest.importorskip("liger_kernel")
+pytest.importorskip("nemo_automodel")
+from transformers import Qwen3Config, Qwen3ForCausalLM
+
+from molt.models import Actor, Critic, PolicyLoss
+from molt.trainer.fsdp import FsdpStrategy
+
+pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="Liger Qwen3 integration requires CUDA")
+
+
+def _save_tiny_qwen3(path):
+    torch.manual_seed(7)
+    config = Qwen3Config(
+        vocab_size=64,
+        hidden_size=32,
+        intermediate_size=64,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=8,
+        max_position_embeddings=64,
+        pad_token_id=0,
+        bos_token_id=1,
+        eos_token_id=2,
+        attention_dropout=0.0,
+    )
+    Qwen3ForCausalLM(config).save_pretrained(path)
+
+
+def _strategy():
+    world_size = int(os.environ["WORLD_SIZE"])
+    args = SimpleNamespace(
+        local_rank=int(os.environ["LOCAL_RANK"]),
+        fsdp=SimpleNamespace(
+            tp_size=1,
+            cp_size=1,
+            ep_size=1,
+            pp_size=1,
+            param_dtype="bf16",
+            offload="none",
+            sequence_parallel=False,
+        ),
+        actor=SimpleNamespace(gradient_checkpoint="full"),
+        train=SimpleNamespace(dynamic_batch_enable=False),
+    )
+    strategy = FsdpStrategy(
+        seed=7,
+        full_determinism=False,
+        micro_train_batch_size=2,
+        train_batch_size=2 * world_size,
+        args=args,
+    )
+    strategy.setup_distributed()
+    return strategy
+
+
+def _load(model_cls, checkpoint, strategy, packing_samples, use_liger_kernel):
+    return model_cls(
+        str(checkpoint),
+        attn_implementation="flash_attention_2",
+        param_dtype="bf16",
+        device_mesh=strategy.device_mesh,
+        moe_mesh=strategy.moe_mesh,
+        distributed_config=strategy.distributed_config,
+        moe_config=strategy.moe_config,
+        activation_checkpointing="full",
+        packing_samples=packing_samples,
+        use_liger_kernel=use_liger_kernel,
+    )
+
+
+def _batch():
+    device = torch.device("cuda", torch.cuda.current_device())
+    sequences = torch.tensor(
+        [[1, 5, 6, 7, 8, 9, 10, 2], [0, 0, 1, 11, 12, 13, 14, 2]],
+        device=device,
+    )
+    attention_mask = sequences.ne(0)
+    action_mask = torch.tensor([[1, 1, 1, 1], [0, 0, 1, 1]], dtype=torch.bool, device=device)
+    advantages = torch.tensor([[0.5, -0.25, 1.0, 0.75], [0.0, 0.0, -0.5, 0.25]], device=device)
+    return sequences, attention_mask, action_mask, advantages
+
+
+def _policy_step(model, batch, *, dp_size=1):
+    sequences, attention_mask, action_mask, advantages = batch
+    output = model(sequences, action_mask, attention_mask, return_entropy=True)
+    old_log_probs = torch.zeros_like(output.action_log_probs)
+    num_tokens = action_mask.sum() * dp_size
+    loss, reported, *_ = PolicyLoss()(
+        output.action_log_probs,
+        old_log_probs,
+        advantages,
+        action_mask=action_mask,
+        dp_size=dp_size,
+        batch_num_tokens=num_tokens,
+    )
+    return output, loss, reported
+
+
+def _local(tensor):
+    return tensor.to_local() if hasattr(tensor, "to_local") else tensor
+
+
+def _assert_finite(tensors):
+    assert all(torch.isfinite(_local(tensor)).all() for tensor in tensors)
+
+
+@pytest.mark.parametrize("packing_samples", [False, True], ids=["unpacked", "packed"])
+def test_single_rank_liger_qwen3_parity(tmp_path, packing_samples):
+    if os.environ.get("WORLD_SIZE") != "1" or "LOCAL_RANK" not in os.environ:
+        pytest.skip("single-rank case runs under torchrun --nproc-per-node=1")
+    checkpoint = tmp_path / "tiny-qwen3"
+    _save_tiny_qwen3(checkpoint)
+    strategy = _strategy()
+    baseline = _load(Actor, checkpoint, strategy, packing_samples, False)
+    liger = _load(Actor, checkpoint, strategy, packing_samples, True)
+    batch = _batch()
+
+    assert baseline.state_dict().keys() == liger.state_dict().keys()
+    baseline_output, baseline_loss, baseline_reported = _policy_step(baseline, batch)
+    liger_output, liger_loss, liger_reported = _policy_step(liger, batch)
+    _assert_finite(
+        [
+            baseline_output.logits,
+            baseline_output.action_log_probs,
+            baseline_output.entropy,
+            baseline_loss,
+            liger_output.logits,
+            liger_output.action_log_probs,
+            liger_output.entropy,
+            liger_loss,
+        ]
+    )
+    torch.testing.assert_close(_local(liger_output.logits), _local(baseline_output.logits), atol=1e-1, rtol=1e-2)
+    torch.testing.assert_close(
+        liger_output.action_log_probs, baseline_output.action_log_probs, atol=1e-1, rtol=1e-2
+    )
+    torch.testing.assert_close(liger_output.entropy, baseline_output.entropy, atol=1e-1, rtol=1e-2)
+    torch.testing.assert_close(liger_reported, baseline_reported, atol=1e-2, rtol=5e-2)
+
+    action_mask = batch[2]
+    actor_reference_kl = (liger_output.action_log_probs - baseline_output.action_log_probs).masked_select(action_mask)
+    _assert_finite([actor_reference_kl])
+
+    models_and_losses = [(baseline, baseline_loss), (liger, liger_loss)]
+    initial_baseline = {name: _local(param.detach()).clone() for name, param in baseline.named_parameters()}
+    for model, loss in models_and_losses:
+        loss.backward()
+        _assert_finite(param.grad for param in model.parameters() if param.grad is not None)
+    for model, _loss in models_and_losses:
+        torch.optim.AdamW(model.parameters(), lr=1e-3).step()
+        _assert_finite(model.parameters())
+
+    baseline_params = dict(baseline.named_parameters())
+    liger_params = dict(liger.named_parameters())
+    assert any(
+        not torch.equal(_local(baseline_params[name]), value) for name, value in initial_baseline.items()
+    ), "optimizer step did not update the baseline"
+    for name in baseline_params:
+        torch.testing.assert_close(
+            _local(liger_params[name]), _local(baseline_params[name]), atol=1e-2, rtol=1e-2
+        )
+
+    critic = _load(Critic, checkpoint, strategy, packing_samples, True)
+    critic_output = critic(batch[0], batch[2], batch[1])
+    assert critic_output.action_values.shape == batch[2].shape
+    _assert_finite([critic_output.action_values])
+
+
+@pytest.mark.parametrize("packing_samples", [False, True], ids=["unpacked", "packed"])
+def test_fsdp2_liger_qwen3_step_matches_baseline_loss(tmp_path, packing_samples):
+    if os.environ.get("WORLD_SIZE") != "2" or "LOCAL_RANK" not in os.environ:
+        pytest.skip("FSDP2 case runs under torchrun --nproc-per-node=2")
+    checkpoint = tmp_path / f"tiny-qwen3-rank-{os.environ['RANK']}"
+    _save_tiny_qwen3(checkpoint)
+    strategy = _strategy()
+    baseline_model = Qwen3ForCausalLM.from_pretrained(
+        checkpoint,
+        torch_dtype=torch.bfloat16,
+        attn_implementation="flash_attention_2",
+    ).cuda()
+    baseline_model.config.use_cache = False
+    baseline = Actor(baseline_model, packing_samples=packing_samples)
+    liger = _load(Actor, checkpoint, strategy, packing_samples, True)
+    batch = _batch()
+
+    with torch.no_grad():
+        _baseline_output, _baseline_loss, baseline_reported = _policy_step(baseline, batch)
+    _liger_output, liger_loss, liger_reported = _policy_step(liger, batch, dp_size=2)
+    global_reported = liger_reported.detach().clone()
+    dist.all_reduce(global_reported)
+    global_reported /= dist.get_world_size()
+    torch.testing.assert_close(global_reported, baseline_reported, atol=1e-2, rtol=5e-2)
+
+    liger_loss.backward()
+    _assert_finite(param.grad for param in liger.parameters() if param.grad is not None)
+    torch.optim.AdamW(liger.parameters(), lr=1e-3).step()
+    _assert_finite(liger.parameters())

--- a/tests/gpu/test_liger_qwen3.py
+++ b/tests/gpu/test_liger_qwen3.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
+from importlib.util import find_spec
 from types import SimpleNamespace
 
 import pytest
@@ -68,7 +69,7 @@ def _strategy():
 def _load(model_cls, checkpoint, strategy, packing_samples, use_liger_kernel):
     return model_cls(
         str(checkpoint),
-        attn_implementation="flash_attention_2",
+        attn_implementation="te" if packing_samples else "sdpa",
         param_dtype="bf16",
         device_mesh=strategy.device_mesh,
         moe_mesh=strategy.moe_mesh,
@@ -120,11 +121,17 @@ def _assert_finite(tensors):
 def test_single_rank_liger_qwen3_parity(tmp_path, packing_samples):
     if os.environ.get("WORLD_SIZE") != "1" or "LOCAL_RANK" not in os.environ:
         pytest.skip("single-rank case runs under torchrun --nproc-per-node=1")
+    if packing_samples and find_spec("transformer_engine") is None:
+        pytest.skip("packed native Qwen3 requires transformer-engine")
     checkpoint = tmp_path / "tiny-qwen3"
     _save_tiny_qwen3(checkpoint)
     strategy = _strategy()
     baseline = _load(Actor, checkpoint, strategy, packing_samples, False)
     liger = _load(Actor, checkpoint, strategy, packing_samples, True)
+    assert any(
+        name.endswith(".mlp") and module.forward.__module__.startswith("liger_kernel.")
+        for name, module in liger.named_modules()
+    )
     batch = _batch()
 
     assert baseline.state_dict().keys() == liger.state_dict().keys()
@@ -182,28 +189,24 @@ def test_single_rank_liger_qwen3_parity(tmp_path, packing_samples):
 def test_fsdp2_liger_qwen3_step_matches_baseline_loss(tmp_path, packing_samples):
     if os.environ.get("WORLD_SIZE") != "2" or "LOCAL_RANK" not in os.environ:
         pytest.skip("FSDP2 case runs under torchrun --nproc-per-node=2")
+    if packing_samples and find_spec("transformer_engine") is None:
+        pytest.skip("packed native Qwen3 requires transformer-engine")
     checkpoint = tmp_path / f"tiny-qwen3-rank-{os.environ['RANK']}"
     _save_tiny_qwen3(checkpoint)
     strategy = _strategy()
-    baseline_model = Qwen3ForCausalLM.from_pretrained(
-        checkpoint,
-        torch_dtype=torch.bfloat16,
-        attn_implementation="flash_attention_2",
-    ).cuda()
-    baseline_model.config.use_cache = False
-    baseline = Actor(baseline_model, packing_samples=packing_samples)
+    baseline = _load(Actor, checkpoint, strategy, packing_samples, False)
     liger = _load(Actor, checkpoint, strategy, packing_samples, True)
     batch = _batch()
 
-    with torch.no_grad():
-        _baseline_output, _baseline_loss, baseline_reported = _policy_step(baseline, batch)
+    _baseline_output, baseline_loss, baseline_reported = _policy_step(baseline, batch, dp_size=2)
     _liger_output, liger_loss, liger_reported = _policy_step(liger, batch, dp_size=2)
-    global_reported = liger_reported.detach().clone()
-    dist.all_reduce(global_reported)
-    global_reported /= dist.get_world_size()
-    torch.testing.assert_close(global_reported, baseline_reported, atol=1e-2, rtol=5e-2)
+    for reported in (baseline_reported, liger_reported):
+        dist.all_reduce(reported)
+        reported /= dist.get_world_size()
+    torch.testing.assert_close(liger_reported, baseline_reported, atol=1e-2, rtol=5e-2)
 
-    liger_loss.backward()
-    _assert_finite(param.grad for param in liger.parameters() if param.grad is not None)
-    torch.optim.AdamW(liger.parameters(), lr=1e-3).step()
-    _assert_finite(liger.parameters())
+    for model, loss in ((baseline, baseline_loss), (liger, liger_loss)):
+        loss.backward()
+        _assert_finite(param.grad for param in model.parameters() if param.grad is not None)
+        torch.optim.AdamW(model.parameters(), lr=1e-3).step()
+        _assert_finite(model.parameters())

--- a/tests/unit/test_liger_kernel.py
+++ b/tests/unit/test_liger_kernel.py
@@ -1,0 +1,149 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import sys
+from types import MethodType, ModuleType, SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+import torch.nn as nn
+
+from molt.cli.common_args import add_fsdp_args
+from molt.models import base
+
+
+def _stub_model(patched: bool):
+    model = nn.Module()
+    model.config = SimpleNamespace(use_cache=True)
+
+    def forward(self, **kwargs):
+        return kwargs
+
+    if patched:
+        forward.__module__ = "liger_kernel.transformers.qwen3"
+    model.forward = MethodType(forward, model)
+    return model
+
+
+def _mesh(tp_size=1, cp_size=1):
+    mesh = MagicMock()
+    mesh.mesh_dim_names = ("tp", "cp")
+    sizes = {"tp": tp_size, "cp": cp_size}
+    mesh.__getitem__.side_effect = lambda name: SimpleNamespace(size=lambda: sizes[name])
+    return mesh
+
+
+@pytest.fixture
+def loader_env(monkeypatch):
+    state = {
+        "model": _stub_model(patched=True),
+        "predicted_hf": True,
+        "loaded_native": False,
+        "is_vlm": False,
+    }
+    calls = []
+
+    class StubLoader:
+        @classmethod
+        def from_pretrained(cls, _path, **kwargs):
+            calls.append(kwargs)
+            return state["model"]
+
+    nemo = ModuleType("nemo_automodel")
+    nemo.NeMoAutoModelForCausalLM = StubLoader
+    nemo.NeMoAutoModelForImageTextToText = StubLoader
+    config = ModuleType("nemo_automodel.components.distributed.config")
+    config.DistributedSetup = lambda **kwargs: SimpleNamespace(**kwargs)
+    mesh = ModuleType("nemo_automodel.components.distributed.mesh")
+    mesh.MeshContext = SimpleNamespace(from_meshes=lambda *meshes: meshes)
+    for name, module in {
+        "nemo_automodel": nemo,
+        "nemo_automodel.components": ModuleType("nemo_automodel.components"),
+        "nemo_automodel.components.distributed": ModuleType("nemo_automodel.components.distributed"),
+        "nemo_automodel.components.distributed.config": config,
+        "nemo_automodel.components.distributed.mesh": mesh,
+    }.items():
+        monkeypatch.setitem(sys.modules, name, module)
+
+    from molt.utils import utils
+
+    monkeypatch.setattr(base, "find_spec", lambda _name: object())
+    monkeypatch.setattr(base, "_detect_moe_arch", lambda _path: False)
+    monkeypatch.setattr(base, "_will_use_hf_model", lambda _path: state["predicted_hf"])
+    monkeypatch.setattr(base, "_validate_attn_implementation", lambda _attn: None)
+    monkeypatch.setattr(base, "_mtp_off_kwargs", lambda _path: {})
+    monkeypatch.setattr(base, "move_model_to_cpu_for_offload", lambda model, _config: model)
+    monkeypatch.setattr(base, "configure_nemo_moe_aux_loss", lambda *_args: None)
+    monkeypatch.setattr(base, "is_automodel_custom_model", lambda _model: state["loaded_native"])
+    monkeypatch.setattr(utils, "is_vlm_model", lambda _path: state["is_vlm"])
+    return state, calls
+
+
+def test_shared_parser_defaults_off_and_accepts_opt_in():
+    parser = argparse.ArgumentParser()
+    add_fsdp_args(parser)
+
+    assert vars(parser.parse_args([]))["fsdp.use_liger_kernel"] is False
+    assert vars(parser.parse_args(["--fsdp.use_liger_kernel"]))["fsdp.use_liger_kernel"] is True
+
+
+@pytest.mark.parametrize(("enabled", "patched"), [(False, False), (True, True)])
+def test_loader_receives_exact_liger_setting(loader_env, enabled, patched):
+    state, calls = loader_env
+    state["model"] = _stub_model(patched)
+
+    base.BaseModel("qwen3", use_liger_kernel=enabled)
+
+    assert calls[0]["use_liger_kernel"] is enabled
+
+
+@pytest.mark.parametrize("unsupported", ["missing", "native", "tp", "cp", "ep", "sp", "vlm", "instance"])
+def test_liger_rejects_unsupported_request_before_model_load(loader_env, monkeypatch, unsupported):
+    state, calls = loader_env
+    kwargs = {"use_liger_kernel": True}
+    model = "qwen3"
+
+    if unsupported == "missing":
+        monkeypatch.setattr(base, "find_spec", lambda _name: None)
+    elif unsupported == "native":
+        state["predicted_hf"] = False
+    elif unsupported == "tp":
+        kwargs["device_mesh"] = _mesh(tp_size=2)
+    elif unsupported == "cp":
+        kwargs["device_mesh"] = _mesh(cp_size=2)
+    elif unsupported == "ep":
+        kwargs["moe_mesh"] = object()
+    elif unsupported == "sp":
+        kwargs["distributed_config"] = SimpleNamespace(sequence_parallel=True)
+    elif unsupported == "vlm":
+        state["is_vlm"] = True
+    else:
+        model = nn.Linear(2, 2)
+
+    with pytest.raises((RuntimeError, ValueError), match="use_liger_kernel"):
+        base.BaseModel(model, **kwargs)
+
+    assert calls == []
+
+
+@pytest.mark.parametrize(("patched", "loaded_native"), [(False, False), (True, True)])
+def test_liger_rejects_unpatched_or_native_loader_result(loader_env, capsys, patched, loaded_native):
+    state, calls = loader_env
+    state["model"] = _stub_model(patched)
+    state["loaded_native"] = loaded_native
+
+    with pytest.raises(RuntimeError, match="without observable Liger patch evidence"):
+        base.BaseModel("qwen3", use_liger_kernel=True)
+
+    assert len(calls) == 1
+    assert "[Liger] enabled" not in capsys.readouterr().out
+
+
+def test_liger_reports_rank_zero_success_after_patch_evidence(loader_env, capsys):
+    _state, calls = loader_env
+
+    base.BaseModel("qwen3", use_liger_kernel=True)
+
+    assert len(calls) == 1
+    assert capsys.readouterr().out.count("[Liger] enabled on HF backend.") == 1

--- a/tests/unit/test_liger_kernel.py
+++ b/tests/unit/test_liger_kernel.py
@@ -14,15 +14,26 @@ from molt.models import base
 
 
 def _stub_model(patched: bool):
+    class Qwen3MLP(nn.Module):
+        pass
+
+    class Qwen3RMSNorm(nn.Module):
+        pass
+
     model = nn.Module()
-    model.config = SimpleNamespace(use_cache=True)
+    model.config = SimpleNamespace(use_cache=True, model_type="qwen3")
+    model.mlp = Qwen3MLP()
+    model.norm = Qwen3RMSNorm()
 
     def forward(self, **kwargs):
         return kwargs
 
-    if patched:
-        forward.__module__ = "liger_kernel.transformers.qwen3"
     model.forward = MethodType(forward, model)
+    for module in (model.mlp, model.norm):
+        module.forward = MethodType(forward, module)
+    if patched:
+        for module in (model.mlp, model.norm):
+            module.forward.__func__.__module__ = "liger_kernel.transformers.qwen3"
     return model
 
 
@@ -57,12 +68,23 @@ def loader_env(monkeypatch):
     config.DistributedSetup = lambda **kwargs: SimpleNamespace(**kwargs)
     mesh = ModuleType("nemo_automodel.components.distributed.mesh")
     mesh.MeshContext = SimpleNamespace(from_meshes=lambda *meshes: meshes)
+    liger_patch = ModuleType("liger_kernel.transformers.monkey_patch")
+
+    def apply_liger_kernel_to_qwen3(*, model, **_kwargs):
+        for module in model.modules():
+            if type(module).__name__ in {"Qwen3MLP", "Qwen3RMSNorm"}:
+                module.forward.__func__.__module__ = "liger_kernel.transformers.qwen3"
+
+    liger_patch.apply_liger_kernel_to_qwen3 = apply_liger_kernel_to_qwen3
     for name, module in {
         "nemo_automodel": nemo,
         "nemo_automodel.components": ModuleType("nemo_automodel.components"),
         "nemo_automodel.components.distributed": ModuleType("nemo_automodel.components.distributed"),
         "nemo_automodel.components.distributed.config": config,
         "nemo_automodel.components.distributed.mesh": mesh,
+        "liger_kernel": ModuleType("liger_kernel"),
+        "liger_kernel.transformers": ModuleType("liger_kernel.transformers"),
+        "liger_kernel.transformers.monkey_patch": liger_patch,
     }.items():
         monkeypatch.setitem(sys.modules, name, module)
 
@@ -88,17 +110,17 @@ def test_shared_parser_defaults_off_and_accepts_opt_in():
     assert vars(parser.parse_args(["--fsdp.use_liger_kernel"]))["fsdp.use_liger_kernel"] is True
 
 
-@pytest.mark.parametrize(("enabled", "patched"), [(False, False), (True, True)])
-def test_loader_receives_exact_liger_setting(loader_env, enabled, patched):
+@pytest.mark.parametrize(("enabled", "patched"), [(False, False), (True, False)])
+def test_loader_defers_liger_patching_until_after_load(loader_env, enabled, patched):
     state, calls = loader_env
     state["model"] = _stub_model(patched)
 
     base.BaseModel("qwen3", use_liger_kernel=enabled)
 
-    assert calls[0]["use_liger_kernel"] is enabled
+    assert calls[0]["use_liger_kernel"] is False
 
 
-@pytest.mark.parametrize("unsupported", ["missing", "native", "tp", "cp", "ep", "sp", "vlm", "instance"])
+@pytest.mark.parametrize("unsupported", ["missing", "tp", "cp", "ep", "sp", "vlm", "instance"])
 def test_liger_rejects_unsupported_request_before_model_load(loader_env, monkeypatch, unsupported):
     state, calls = loader_env
     kwargs = {"use_liger_kernel": True}
@@ -106,8 +128,6 @@ def test_liger_rejects_unsupported_request_before_model_load(loader_env, monkeyp
 
     if unsupported == "missing":
         monkeypatch.setattr(base, "find_spec", lambda _name: None)
-    elif unsupported == "native":
-        state["predicted_hf"] = False
     elif unsupported == "tp":
         kwargs["device_mesh"] = _mesh(tp_size=2)
     elif unsupported == "cp":
@@ -127,13 +147,12 @@ def test_liger_rejects_unsupported_request_before_model_load(loader_env, monkeyp
     assert calls == []
 
 
-@pytest.mark.parametrize(("patched", "loaded_native"), [(False, False), (True, True)])
-def test_liger_rejects_unpatched_or_native_loader_result(loader_env, capsys, patched, loaded_native):
+def test_liger_rejects_missing_qwen3_layers(loader_env, capsys):
     state, calls = loader_env
-    state["model"] = _stub_model(patched)
-    state["loaded_native"] = loaded_native
+    state["model"] = nn.Module()
+    state["model"].config = SimpleNamespace(use_cache=True, model_type="qwen3")
 
-    with pytest.raises(RuntimeError, match="without observable Liger patch evidence"):
+    with pytest.raises(RuntimeError, match="did not patch every Qwen3"):
         base.BaseModel("qwen3", use_liger_kernel=True)
 
     assert len(calls) == 1
@@ -146,4 +165,4 @@ def test_liger_reports_rank_zero_success_after_patch_evidence(loader_env, capsys
     base.BaseModel("qwen3", use_liger_kernel=True)
 
     assert len(calls) == 1
-    assert capsys.readouterr().out.count("[Liger] enabled on HF backend.") == 1
+    assert capsys.readouterr().out.count("[Liger] enabled on hf Qwen3 backend.") == 1


### PR DESCRIPTION
## Summary

This PR adds an opt-in path for Liger layer kernels in Molt. Liger-kernels provides potential optimizations (in-practice they interestingly increase throughput but also memory usage). The PR selectively replaces compatible transformer-layer forwards while Molt retains ownership of the model-loading, attention, packing, and training paths. The flag remains opt-in and default-off.

The integration is model-level: native AutoModel architectures can have different module layouts, so each architecture needs explicit patching and parity validation. This PR enables dense text Qwen3 as the first validated
architecture. It applies Liger directly to the loaded Qwen3 instance and replaces only its MLP and decoder/final RMSNorm forwards.

For this initial Qwen3 support, native padded BSHD and TE-packed THD layouts are supported with TP, CP, EP, and sequence parallelism all set to one. VLMs remain unsupported.

## Why attention, RoPE, and RL loss stay in Molt

Molt's native AutoModel path owns packed-sequence handling, context parallelism, Transformer Engine attention, and the associated RoPE layout. Replacing them with Liger's Hugging Face-oriented patches could alter those semantics or diverge from rollout inference.

Molt RL also needs materialized logits for action log-probabilities, entropy, KL, PPO/GRPO losses, and rewards. Liger's fused linear cross-entropy avoids materializing logits for supervised LM training, so it is intentionally not enabled here.

## Validation

### Correctness

- Unit coverage: 12 Liger tests passed.
- Native padded Qwen3 GPU parity: passed on one B200 GPU.
- Native padded Qwen3 FSDP loss/backward/update test: passed on two B200 GPUs.
- Full suite: 209 passed, 3 skipped.
- `python -m compileall -q molt examples/python tests` and `git diff --check`
  passed.

`Qwen/Qwen3-4B` is the representative real-model validation case for this initial architecture. Parity was measured through Molt's native AutoModel path with BF16 mixed precision, padded SDPA, one B200 GPU, the same two-sample, eight-token parity input, and one AdamW step (`lr=1e-3`):

| Quantity | Max absolute difference | Mean absolute difference | L-infinity / baseline max |
| --- | ---: | ---: | ---: |
| Logits | `8.7082386e-4` | `2.2494090e-5` | `4.0752126e-5` |
| Action log-probs | `1.3351440e-5` | `5.1259995e-6` | `6.4167313e-7` |
| Entropy | `1.9073486e-5` | `1.0626657e-5` | `2.3754510e-6` |
| Optimization loss | `0` | `0` | `0` |
| Reported loss | `0` | `0` | `0` |
| Gradients, worst tensor | `3.0100346e-6` | `5.3618911e-11` | `2.0269095e-5` |

The largest AdamW update difference was `8.9158025e-4` in layer 35's MLP down projection (mean difference `3.9335588e-9`). It is below the current parameter parity tolerance (`1e-2`) but is not bitwise-equivalent and is disclosed here. Relative errors per individual element are intentionally not reported because they are unstable near zero.

### One-run performance smoke test

The one-run performance smoke test uses `Qwen/Qwen3-4B`, native padded SDPA, BF16, two B200 GPUs, batch size 2, sequence length 2048, five warmups, and 20 measured steps:

| Metric, per rank | Baseline | Liger | Change |
| --- | ---: | ---: | ---: |
| Median step time | 491.7 ms | 448.2 ms | 8.8% faster |
| Tokens/second | 12,487 | 13,698 | 9.7% higher |
| Peak allocated memory | 42.40 GB | 43.72 GB | 3.1% higher |
| Peak reserved memory | 54.67 GB | 61.51 GB | 12.5% higher |

This is one paired run, not a statistical performance claim. Liger improved throughput in this configuration but did not reduce memory, so this PR makes no memory-efficiency claim.

## Limitations and follow-ups

- Packed native Qwen3 correctness is not yet validated on Transformer Engine. The tests skip that case explicitly rather than passing vacuously; the tracked commands run pytest under `torchrun`.
- Liger supports many model types, but this PR enables only Qwen3. Native AutoModel can alter module layouts, so each additional architecture should be explicitly validated before it is enabled but not sure how likely/unlikely it is for things to break here.
- A good follow-up issue is to extend this integration to additional Liger-supported text models one architecture at a time: add a parity fixture, verify observable instance patching, run a real-model smoke test, then add it to the public allowlist. 
