### PR TITLE
feat(sft): add --data.pad_to_max_len to fix MoE+EP gradient-checkpoint crash (AutoModel#3325)

### DIFF
--- a/examples/scripts/quick_start/sft_qwen3_6_35b.sh
+++ b/examples/scripts/quick_start/sft_qwen3_6_35b.sh
@@ -54,6 +54,7 @@ export PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
 cd "$REPO_ROOT"
 torchrun --standalone --nproc_per_node="$GPUS_PER_NODE" -m molt.cli.train_sft \
   --data.max_len "$MAX_LEN" \
+  --data.pad_to_max_len \
   --data.dataset "$SFT_DATASET" \
   --data.input_key prompt \
   --data.output_key response \

--- a/examples/scripts/slurm/sft_qwen3_6_35b.sh
+++ b/examples/scripts/slurm/sft_qwen3_6_35b.sh
@@ -92,6 +92,7 @@ head_addr="$(srun --nodes=1 --ntasks=1 -w "$head_node" hostname --ip-address | a
 
 TRAIN_ARGS=(
   --data.max_len "$MAX_LEN"
+  --data.pad_to_max_len
   --data.dataset "$SFT_DATASET"
   --data.input_key prompt
   --data.output_key response

--- a/molt/cli/train_sft.py
+++ b/molt/cli/train_sft.py
@@ -66,6 +66,7 @@ def train(args):
         image_key=args.data.image_key,
         max_images_per_prompt=args.data.max_images_per_prompt,
         train_on_last_turn_only=args.data.train_on_last_turn_only,
+        pad_to_max_len=args.data.pad_to_max_len,
     )
     train_dataloader = strategy.setup_dataloader(
         train_dataset,
@@ -92,6 +93,7 @@ def train(args):
             image_key=args.data.image_key,
             max_images_per_prompt=args.data.max_images_per_prompt,
             train_on_last_turn_only=args.data.train_on_last_turn_only,
+            pad_to_max_len=args.data.pad_to_max_len,
         )
         eval_dataloader = strategy.setup_dataloader(
             eval_dataset,
@@ -193,6 +195,12 @@ if __name__ == "__main__":
     parser.add_argument("--data.dataset_split", type=str, default="train")
     parser.add_argument("--data.max_samples", type=int, default=1000000, help="Maximum number of samples to use")
     parser.add_argument("--data.max_len", type=int, default=2048, help="Max total sequence length (prompt + response)")
+    parser.add_argument(
+        "--data.pad_to_max_len",
+        action="store_true",
+        default=False,
+        help="Pad every batch to --data.max_len (needed for MoE + ep_size>1 + gradient_checkpoint).",
+    )
     parser.add_argument("--data.input_key", type=str, default="input", help="JSON dataset key")
     parser.add_argument(
         "--data.output_key", type=str, default=None, help="Dataset column holding the assistant reply (SFT target)."

--- a/molt/datasets/sft_dataset.py
+++ b/molt/datasets/sft_dataset.py
@@ -130,6 +130,7 @@ class SFTDataset(Dataset):
         image_key: Optional[str] = None,
         max_images_per_prompt: int = 4,
         train_on_last_turn_only: bool = False,
+        pad_to_max_len: bool = False,
     ) -> None:
         super().__init__()
         # An AutoProcessor (VLM) keeps the plain text tokenizer under `.tokenizer`.
@@ -137,6 +138,7 @@ class SFTDataset(Dataset):
         self.text_tokenizer = getattr(tokenizer, "tokenizer", tokenizer)
         self.processor = tokenizer if hasattr(tokenizer, "image_processor") else None
         self.max_length = max_length
+        self.pad_to_max_len = pad_to_max_len
         self.image_key = image_key
         self.max_images_per_prompt = max_images_per_prompt
         self.train_on_last_turn_only = train_on_last_turn_only
@@ -329,10 +331,11 @@ class SFTDataset(Dataset):
     # ------------------------------------------------------------------
     def collate_fn(self, items):
         input_ids, attention_mask, loss_mask, mm_inputs = zip(*items)
+        pad_to = self.max_length if self.pad_to_max_len else None
         return (
-            zero_pad_sequences(list(input_ids), "right", self.pad_token_id),
-            zero_pad_sequences(list(attention_mask), "right"),
-            zero_pad_sequences(list(loss_mask), "right"),
+            zero_pad_sequences(list(input_ids), "right", self.pad_token_id, pad_to=pad_to),
+            zero_pad_sequences(list(attention_mask), "right", pad_to=pad_to),
+            zero_pad_sequences(list(loss_mask), "right", pad_to=pad_to),
             self._stack_mm_inputs(mm_inputs),
         )
 

--- a/molt/utils/utils.py
+++ b/molt/utils/utils.py
@@ -16,7 +16,7 @@
 # Adapted from OpenRLHF (https://github.com/OpenRLHF/OpenRLHF),
 # Copyright (c) OpenRLHF contributors, licensed under the Apache License, Version 2.0.
 
-from typing import List
+from typing import List, Optional
 
 import torch
 import torch.nn.functional as F
@@ -91,10 +91,12 @@ def get_tokenizer(pretrain, model, padding_side="left", use_fast=True):
 
 
 def zero_pad_sequences(
-    sequences: List[torch.Tensor], side: str = "left", value: int = 0, stack: bool = False
+    sequences: List[torch.Tensor], side: str = "left", value: int = 0, stack: bool = False, pad_to: Optional[int] = None
 ) -> torch.Tensor:
     assert side in ("left", "right")
     max_len = max(seq.size(-1) for seq in sequences)
+    if pad_to is not None:
+        max_len = max(max_len, pad_to)
     padded_sequences = []
     for seq in sequences:
         pad_len = max_len - seq.size(-1)


### PR DESCRIPTION
## What

Adds `--data.pad_to_max_len` (default **off**) to SFT. When on, every batch is
padded to `--data.max_len` so all EP ranks see fixed, identical token
dimensions. Enabled in the two shipped recipes that hit the failing combo
(`quick_start/` + `slurm/` `sft_qwen3_6_35b`).

## The bug we hit

Full-finetuning a custom MoE (Qwen3.6-35B-A3B) with `--fsdp.ep_size>1` and
`--model.gradient_checkpoint full` crashes at the **first backward**:

```
torch.utils.checkpoint.CheckpointError: Recomputed values for the following
tensors have different metadata than during the forward pass.
saved metadata:      {'shape': torch.Size([1337, 2048]), ...}
recomputed metadata: {'shape': torch.Size([1321, 2048]), ...}
```

The DeepEP dispatcher permutes tokens by expert routing, so each rank's
**post-dispatch token count depends on the global batch**. With variable-length
batches (micro_batch=1, batch-max padding), the activation-checkpoint recompute
re-runs dispatch and lands on a different per-rank count than the forward saved
— so `torch.utils.checkpoint` aborts. DeepEP also requires identical token dims
across GPUs (see [deepseek-ai/DeepEP#604](https://github.com/deepseek-ai/DeepEP/issues/604)).
The global token total is conserved; only the
per-rank split drifts, and it's data-dependent (we saw both 1337→1321 and
1030→1056 across runs).

## The fix — ported from AutoModel

AutoModel already solved this at the preprocessing layer with
`SFTSingleTurnPreprocessor(pad_to_max_length=True)`. Molt's own data path
(`zero_pad_sequences` = batch-max) had no equivalent knob, so it didn't inherit
that behavior. This PR ports the same idea: pad to a fixed length so dispatch is
reproducible under recompute and token dims match across ranks.

- `zero_pad_sequences(..., pad_to=None)`; `max(pad_to, batch_max)` guards the
  rare VLM sample whose images alone exceed `pad_to` (never pads negative).
- `SFTDataset(pad_to_max_len=...)` threaded into `collate_fn`. Default off keeps
  the current batch-max behavior; the RL path (`experience.py`) is untouched.
- `--data.pad_to_max_len` CLI flag + both recipe wirings.

TP is intentionally left at 1 — AutoModel's custom MoE parallelizer requires it;
this fix is orthogonal to the attention backend.

## Verification

On 4×H20 (EP scaled 8→4 for the box), same shipped recipe:

| Config (EP=4, TP=1, `gradient_checkpoint full`) | first backward | step 1 |
|---|---|---|
| batch-max padding (before) | `CheckpointError` on all ranks | never reached |
| `--data.pad_to_max_len` (after) | ✅ passes | ✅ `sft_loss≈2.16, grad_norm≈286` |

A full SFT step completes under **both** `flash_attention_2` (→sdpa for the
custom model) and `te` backends; zero `CheckpointError`.

- `python -m compileall -q molt examples/python tests` — clean
- `python -m pytest -q tests/unit` — 192 passed
- `bash -n` on both recipes — OK

## Not included

`slurm/sft_omni3_30b.sh` uses a different config (CP=8 sharding + `te` + 32K) and
its comments already assert deterministic recompute; left untouched pending a
separate confirmation.

Fixes [NVIDIA-NeMo/Automodel#3325](https://github.com/NVIDIA-NeMo/Automodel/issues/3325). Refs [deepseek-ai/DeepEP#604](https://github.com/deepseek-ai/DeepEP/issues/604).
