### PR TITLE
fix(rl): improve evaluation and W&B integration

### DIFF
--- a/molt/cli/train_rl_ray.py
+++ b/molt/cli/train_rl_ray.py
@@ -22,6 +22,32 @@ import os
 from molt.trainer.algorithm.experience import get_model_parallel_size
 
 
+def _ray_runtime_env_vars():
+    """Build the environment inherited by Ray workers."""
+    env_vars = {
+        "TOKENIZERS_PARALLELISM": os.environ.get("TOKENIZERS_PARALLELISM", "true"),
+        "NCCL_DEBUG": os.environ.get("NCCL_DEBUG", "WARN"),
+        "RAY_ENABLE_ZERO_COPY_TORCH_TENSORS": os.environ.get("RAY_ENABLE_ZERO_COPY_TORCH_TENSORS", "1"),
+    }
+    for name in (
+        "FLASHINFER_WORKSPACE_BASE",
+        "FLASHINFER_WORKSPACE_DIR",
+        "HF_HOME",
+        "HF_HUB_CACHE",
+        "HUGGINGFACE_HUB_CACHE",
+        "TRANSFORMERS_CACHE",
+        "TORCH_COMPILE_DISABLE",
+        "PYTORCH_CUDA_ALLOC_CONF",
+        "VLLM_WORKER_MULTIPROC_METHOD",
+        "WANDB_API_KEY",
+        "WANDB_ENTITY",
+        "WANDB_MODE",
+    ):
+        if os.environ.get(name):
+            env_vars[name] = os.environ[name]
+    return env_vars
+
+
 def train(args):
     import ray
     from ray.util.placement_group import placement_group
@@ -37,25 +63,7 @@ def train(args):
         # Defaults respect user overrides (e.g. NCCL_DEBUG=INFO via
         # `ray job submit --runtime-env-json`); the listed names are
         # cache/workspace knobs vLLM and HF read inside Ray actors.
-        env_vars = {
-            "TOKENIZERS_PARALLELISM": os.environ.get("TOKENIZERS_PARALLELISM", "true"),
-            "NCCL_DEBUG": os.environ.get("NCCL_DEBUG", "WARN"),
-            "RAY_ENABLE_ZERO_COPY_TORCH_TENSORS": os.environ.get("RAY_ENABLE_ZERO_COPY_TORCH_TENSORS", "1"),
-        }
-        for name in (
-            "FLASHINFER_WORKSPACE_BASE",
-            "FLASHINFER_WORKSPACE_DIR",
-            "HF_HOME",
-            "HF_HUB_CACHE",
-            "HUGGINGFACE_HUB_CACHE",
-            "TRANSFORMERS_CACHE",
-            "TORCH_COMPILE_DISABLE",
-            "PYTORCH_CUDA_ALLOC_CONF",
-            "VLLM_WORKER_MULTIPROC_METHOD",
-        ):
-            if os.environ.get(name):
-                env_vars[name] = os.environ[name]
-        ray.init(runtime_env={"env_vars": env_vars})
+        ray.init(runtime_env={"env_vars": _ray_runtime_env_vars()})
 
     # configure strategy
     strategy = get_strategy(args)
@@ -823,6 +831,12 @@ if __name__ == "__main__":
 
     # Eval
     parser.add_argument("--eval.dataset", type=str, default=None, help="Path to the evaluation dataset")
+    parser.add_argument(
+        "--eval.batch_size",
+        type=int,
+        default=None,
+        help="Concurrent eval prompt groups; defaults to --rollout.batch_size when unset.",
+    )
     parser.add_argument("--eval.split", type=str, default="train")
     parser.add_argument("--eval.steps", type=int, default=-1, help="Evaluate every N steps; -1 disables eval.")
     parser.add_argument(

--- a/molt/trainer/rollout/samples_generator.py
+++ b/molt/trainer/rollout/samples_generator.py
@@ -159,6 +159,12 @@ class SamplesGenerator:
     @torch.no_grad()
     def generate_eval_samples(self, **generate_kwargs) -> List[Experience]:
         """Generate evaluation samples for the entire eval dataloader."""
+        eval_batch_size = getattr(getattr(self.args, "eval", None), "batch_size", None)
+        if eval_batch_size is None:
+            eval_batch_size = self.args.rollout.batch_size
+        if eval_batch_size <= 0:
+            raise ValueError("--eval.batch_size must be greater than zero")
+
         if getattr(self, "_eval_dataloader_iter", None) is None:
             self._eval_dataloader_iter = iter(self.eval_dataloader)
 
@@ -167,7 +173,7 @@ class SamplesGenerator:
             while True:
                 experiences, _, exhausted = self._generate_batch(
                     dataloader_iter=self._eval_dataloader_iter,
-                    num_prompts=self.args.rollout.batch_size,
+                    num_prompts=eval_batch_size,
                     dynamic_filtering=False,
                     **generate_kwargs,
                 )

--- a/molt/utils/logging_utils.py
+++ b/molt/utils/logging_utils.py
@@ -91,8 +91,8 @@ class WandbLogger:
 
         wandb.define_metric("train/global_step")
         wandb.define_metric("train/*", step_metric="train/global_step", step_sync=True)
-        wandb.define_metric("eval/epoch")
-        wandb.define_metric("eval/*", step_metric="eval/epoch", step_sync=True)
+        wandb.define_metric("eval/global_step")
+        wandb.define_metric("eval/*", step_metric="eval/global_step", step_sync=True)
         self.handle = wandb
         self.samples_table = wandb.Table(columns=["global_step", "text", "reward"])
 

--- a/tests/unit/test_logging_utils.py
+++ b/tests/unit/test_logging_utils.py
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+from molt.utils.logging_utils import WandbLogger
+
+
+def test_wandb_eval_metrics_use_global_step(monkeypatch):
+    wandb = SimpleNamespace(
+        api=SimpleNamespace(api_key="already-set"),
+        login=Mock(),
+        init=Mock(),
+        define_metric=Mock(),
+        Table=Mock(return_value=SimpleNamespace(columns=[], data=[])),
+    )
+    monkeypatch.setitem(__import__("sys").modules, "wandb", wandb)
+    args = SimpleNamespace(
+        logger=SimpleNamespace(
+            wandb=SimpleNamespace(key="env", org=None, project="test-project", group=None, run_name="test")
+        )
+    )
+
+    WandbLogger(args)
+
+    wandb.define_metric.assert_any_call("eval/global_step")
+    wandb.define_metric.assert_any_call("eval/*", step_metric="eval/global_step", step_sync=True)

--- a/tests/unit/test_samples_generator.py
+++ b/tests/unit/test_samples_generator.py
@@ -35,6 +35,7 @@ if "ray" not in sys.modules:
         return decorator
 
     fake_ray.remote = remote
+    fake_ray.put = MagicMock()
     fake_ray.get = MagicMock()
     fake_ray.wait = MagicMock()
     fake_ray.cancel = MagicMock()
@@ -132,6 +133,66 @@ def test_generate_samples_emits_short_batch_when_dataloader_exhausted(monkeypatc
     assert prompts_dispatched == 2
     assert exhausted is True
     assert generator._inflight_rollouts == []
+
+
+def _wire_eval_generator(generator, monkeypatch, num_prompts):
+    generator.eval_dataloader = _prompt_loader(num_prompts)
+    dispatch_sizes = []
+
+    def dispatch(prompts, labels, images, **kwargs):
+        dispatch_sizes.append(len(prompts))
+        return [SimpleNamespace(group_id=prompt) for prompt in prompts]
+
+    generator._dispatch_to_agent_runners = dispatch
+    monkeypatch.setattr(
+        samples_generator.ray, "wait", lambda handles, num_returns=1, timeout=None: ([handles[0]], list(handles[1:]))
+    )
+    monkeypatch.setattr(samples_generator.ray, "get", lambda handle: [(_sample(handle.group_id), None)])
+    return dispatch_sizes
+
+
+def test_generate_eval_samples_uses_independent_eval_batch_size(monkeypatch):
+    generator = object.__new__(SamplesGenerator)
+    generator.args = SimpleNamespace(
+        rollout=SimpleNamespace(batch_size=1, n_samples_per_prompt=1),
+        eval=SimpleNamespace(batch_size=4),
+        algo=SimpleNamespace(dynamic_filtering_enable=False),
+    )
+    dispatch_sizes = _wire_eval_generator(generator, monkeypatch, num_prompts=5)
+
+    samples = generator.generate_eval_samples()
+
+    assert [sample.group_ids[0] for sample in samples] == ["p0", "p1", "p2", "p3", "p4"]
+    assert dispatch_sizes == [4, 1]
+
+
+def test_generate_eval_samples_defaults_to_rollout_batch_size(monkeypatch):
+    generator = object.__new__(SamplesGenerator)
+    generator.args = SimpleNamespace(
+        rollout=SimpleNamespace(batch_size=2, n_samples_per_prompt=1),
+        eval=SimpleNamespace(batch_size=None),
+        algo=SimpleNamespace(dynamic_filtering_enable=False),
+    )
+    dispatch_sizes = _wire_eval_generator(generator, monkeypatch, num_prompts=5)
+
+    samples = generator.generate_eval_samples()
+
+    assert len(samples) == 5
+    assert dispatch_sizes == [2, 2, 1]
+
+
+@pytest.mark.parametrize("batch_size", [0, -1])
+def test_generate_eval_samples_rejects_nonpositive_batch_size(batch_size):
+    generator = object.__new__(SamplesGenerator)
+    generator.args = SimpleNamespace(
+        rollout=SimpleNamespace(batch_size=2, n_samples_per_prompt=1),
+        eval=SimpleNamespace(batch_size=batch_size),
+        algo=SimpleNamespace(dynamic_filtering_enable=False),
+    )
+    generator.eval_dataloader = _prompt_loader(1)
+
+    with pytest.raises(ValueError, match="--eval.batch_size must be greater than zero"):
+        generator.generate_eval_samples()
 
 
 def test_generate_samples_pool_persists_across_calls(monkeypatch):

--- a/tests/unit/test_train_rl_ray.py
+++ b/tests/unit/test_train_rl_ray.py
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from molt.cli.train_rl_ray import _ray_runtime_env_vars
+
+
+def test_ray_runtime_env_forwards_wandb_settings(monkeypatch):
+    expected = {
+        "WANDB_API_KEY": "test-api-key",
+        "WANDB_ENTITY": "test-entity",
+        "WANDB_MODE": "offline",
+    }
+    for name, value in expected.items():
+        monkeypatch.setenv(name, value)
+
+    env_vars = _ray_runtime_env_vars()
+
+    assert {name: env_vars[name] for name in expected} == expected
+
+
+def test_ray_runtime_env_omits_empty_optional_settings(monkeypatch):
+    for name in ("WANDB_API_KEY", "WANDB_ENTITY", "WANDB_MODE"):
+        monkeypatch.delenv(name, raising=False)
+
+    env_vars = _ray_runtime_env_vars()
+
+    assert not {"WANDB_API_KEY", "WANDB_ENTITY", "WANDB_MODE"} & env_vars.keys()


### PR DESCRIPTION
## Summary

- forward W&B configuration from the launcher environment to Ray workers
- allow evaluation prompt concurrency to be configured independently from the training rollout batch size
- index W&B evaluation metrics by the actual training global step
- validate non-positive evaluation batch sizes and preserve the existing rollout-batch fallback

## Why

Training rollout batches determine how many prompt groups contribute trajectories to an optimizer step, while evaluation batches only control inference dispatch concurrency. Coupling the two limits evaluation throughput when training requires a small rollout batch.

W&B evaluation logs already emit `eval/global_step`, but the metric definition referenced `eval/epoch`, which was never logged. As a result, charts could fall back to W&B's internal step instead of the training step. Ray workers also need the W&B environment forwarded explicitly when they are initialized with a runtime environment.

## Validation

- `ruff check` on all changed files
- `ruff format --check` on all changed files
- `python -m compileall` on all changed Python files
- `pytest -q tests/unit/test_samples_generator.py tests/unit/test_logging_utils.py tests/unit/test_train_rl_ray.py` — 18 passed
