### PR TITLE
fix(rl): validate --eval.batch_size at launch, not at the first eval

### DIFF
--- a/molt/cli/train_rl_ray.py
+++ b/molt/cli/train_rl_ray.py
@@ -1080,6 +1080,9 @@ if __name__ == "__main__":
     if args.eval.dataset:
         assert args.train.agent_path, "`--eval.dataset` requires `--train.agent_path`."
 
+    if args.eval.batch_size is not None and args.eval.batch_size <= 0:
+        raise ValueError(f"--eval.batch_size must be greater than zero, got {args.eval.batch_size}.")
+
     # --- Runtime ---
     if args.use_ms:
         from modelscope.utils.hf_util import patch_hub

--- a/molt/trainer/rollout/samples_generator.py
+++ b/molt/trainer/rollout/samples_generator.py
@@ -159,12 +159,9 @@ class SamplesGenerator:
     @torch.no_grad()
     def generate_eval_samples(self, **generate_kwargs) -> List[Experience]:
         """Generate evaluation samples for the entire eval dataloader."""
-        eval_batch_size = getattr(getattr(self.args, "eval", None), "batch_size", None)
-        if eval_batch_size is None:
-            eval_batch_size = self.args.rollout.batch_size
-        if eval_batch_size <= 0:
-            raise ValueError("--eval.batch_size must be greater than zero")
-
+        # Eval concurrency is decoupled from the rollout batch; unset falls back to it.
+        # The CLI rejects a non-positive --eval.batch_size, so this cannot be 0 here.
+        eval_batch_size = self.args.eval.batch_size or self.args.rollout.batch_size
         if getattr(self, "_eval_dataloader_iter", None) is None:
             self._eval_dataloader_iter = iter(self.eval_dataloader)
 

--- a/tests/unit/test_samples_generator.py
+++ b/tests/unit/test_samples_generator.py
@@ -181,20 +181,6 @@ def test_generate_eval_samples_defaults_to_rollout_batch_size(monkeypatch):
     assert dispatch_sizes == [2, 2, 1]
 
 
-@pytest.mark.parametrize("batch_size", [0, -1])
-def test_generate_eval_samples_rejects_nonpositive_batch_size(batch_size):
-    generator = object.__new__(SamplesGenerator)
-    generator.args = SimpleNamespace(
-        rollout=SimpleNamespace(batch_size=2, n_samples_per_prompt=1),
-        eval=SimpleNamespace(batch_size=batch_size),
-        algo=SimpleNamespace(dynamic_filtering_enable=False),
-    )
-    generator.eval_dataloader = _prompt_loader(1)
-
-    with pytest.raises(ValueError, match="--eval.batch_size must be greater than zero"):
-        generator.generate_eval_samples()
-
-
 def test_generate_samples_pool_persists_across_calls(monkeypatch):
     generator = object.__new__(SamplesGenerator)
     generator.args = SimpleNamespace(


### PR DESCRIPTION
The check lived in generate_eval_samples(), so `--eval.batch_size 0` only raised when the first eval fired -- with --eval.steps unset that is many steps into a run, hours on a large recipe. Move it next to the other `# --- Eval ---` checks in the CLI, where every other argument is validated and the run dies before any GPU is claimed.

The lookup can then drop its defensive double-getattr: `args.eval` always exists after hierarchize, and 0 can no longer reach it.

Removes the unit test for the runtime raise: molt's CLI validation lives in __main__ and none of it is unit-tested, so there is nowhere for that assertion to move. The two behavioural eval-batch-size tests still cover the knob and its fallback to --rollout.batch_size.