### PR TITLE
fix(metrics): count a multi-turn rollout's reward once, not once per …

### DIFF
--- a/molt/trainer/rl_trainer.py
+++ b/molt/trainer/rl_trainer.py
@@ -123,6 +123,49 @@ def prepare_datasets(strategy, tokenizer):
     return prompts_dataloader, eval_dataloader, max_steps
 
 
+def _dedup_rollout_rewards(rollout_samples):
+    """Terminal reward once per rollout, and once per prompt group.
+
+    A multi-turn rollout appears in ``rollout_samples`` once per step it took, and every one of
+    those rows carries the same terminal reward. Averaging the flattened rows therefore weights
+    each trajectory by its length, and that weighting is not neutral: a failing episode runs to
+    the step cap while a successful one terminates as soon as it is done, so the long trajectories
+    that dominate the mean are exactly the zero-reward ones. On an OSWorld run this reported 0.28
+    where the same checkpoint scored 0.4487 on the same 361 tasks through the eval path, which
+    dedups by group id -- a gap that was entirely the weighting, not the policy. It also
+    manufactured a -0.94 correlation between the reported reward and mean episode length, which
+    is an artefact of the identity rather than a property of the run.
+
+    Rollout identity follows merge_rollout_rewards: ``rollout_ids`` when the agent stamps them,
+    else ``group_ids``, else the per-sample index for legacy single-turn rollouts -- where every
+    row is already its own rollout, so the dedup is an identity.
+
+    Returns (per_rollout_rewards, per_group_rewards) as 1-D tensors.
+    """
+    seen: dict = {}
+    per_rollout: list = []
+    groups: dict = {}
+    for s in rollout_samples:
+        if "reward" not in s.info:
+            continue
+        rewards = s.info["reward"].flatten()
+        rollout_ids = getattr(s, "rollout_ids", None) or getattr(s, "group_ids", None) or list(s.index)
+        group_ids = getattr(s, "group_ids", None) or rollout_ids
+        for i in range(rewards.numel()):
+            rid = rollout_ids[i] if i < len(rollout_ids) else f"_unkeyed{i}"
+            if rid in seen:
+                continue
+            seen[rid] = True
+            per_rollout.append(rewards[i])
+            gid = group_ids[i] if i < len(group_ids) else rid
+            groups.setdefault(gid, []).append(rewards[i])
+    if not per_rollout:
+        empty = torch.zeros(0)
+        return empty, empty
+    per_group = [torch.stack(v).float().mean() for v in groups.values()]
+    return torch.stack(per_rollout), torch.stack(per_group)
+
+
 def compute_eval_metrics(eval_dataloader, samples_list, n_samples_per_prompt):
     """Compute pass@k eval metrics from generated samples.
 
@@ -326,15 +369,24 @@ class BaseRLTrainer:
         # Ground-truth rollout stats over the FULL generated set — from the lightweight fields present
         # on every rollout sample, and computed on `rollout_samples` (before balance_experiences drops
         # the trailing remainder), so num_samples and the means reflect everything we generated.
-        all_rewards = torch.cat([s.info["reward"] for s in rollout_samples if "reward" in s.info])
+        rollout_rewards, group_rewards = _dedup_rollout_rewards(rollout_samples)
         all_response_lengths = torch.cat([s.response_length for s in rollout_samples if s.response_length is not None])
         all_truncated = torch.cat([s.truncated for s in rollout_samples if s.truncated is not None])
+        n_flat = sum(s.info["reward"].numel() for s in rollout_samples if "reward" in s.info)
         rollout_stats = {
-            "rollout/reward_mean": all_rewards.float().mean().item(),
-            "rollout/reward_std": all_rewards.float().std().item() if len(all_rewards) > 1 else 0.0,
+            "rollout/reward_mean": rollout_rewards.float().mean().item() if rollout_rewards.numel() else 0.0,
+            "rollout/reward_std": rollout_rewards.float().std().item() if rollout_rewards.numel() > 1 else 0.0,
+            # Mean over prompt groups of that group's mean reward -- the same quantity
+            # compute_eval_metrics reports as eval pass@1, so train and eval are comparable.
+            "rollout/group_pass_rate": group_rewards.float().mean().item() if group_rewards.numel() else 0.0,
+            # Per TURN, not per rollout: these are genuinely per-generation quantities.
             "rollout/response_length_mean": all_response_lengths.float().mean().item(),
             "rollout/truncated_rate": all_truncated.float().mean().item(),
-            "rollout/num_samples": float(len(all_rewards)),
+            "rollout/num_rollouts": float(rollout_rewards.numel()),
+            "rollout/num_prompt_groups": float(group_rewards.numel()),
+            # Flattened turn-level row count. It sizes the training batch, but it is no longer the
+            # denominator of reward_mean.
+            "rollout/num_samples": float(n_flat),
         }
 
         # Push the experiences to the actor shards (and the critic, which trains on the same batch

--- a/tests/unit/test_dedup_rollout_rewards.py
+++ b/tests/unit/test_dedup_rollout_rewards.py
@@ -1,0 +1,78 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for the per-rollout reward aggregation in rl_trainer."""
+import types
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from molt.trainer.rl_trainer import _dedup_rollout_rewards
+
+
+def _sample(rollout_ids, group_ids, rewards):
+    s = types.SimpleNamespace()
+    s.info = {"reward": torch.tensor(rewards, dtype=torch.float)}
+    s.rollout_ids = rollout_ids
+    s.group_ids = group_ids
+    s.index = list(range(len(rewards)))
+    return s
+
+
+def test_long_failures_do_not_outweigh_short_successes():
+    # Two prompt groups, each with one 2-turn success and one 6-turn failure. The flattened mean
+    # is 4/16 = 0.25; the honest pass rate is 2/4 = 0.5. This 2x gap is the bug, at the same
+    # magnitude seen on OSWorld (reported 0.28 against a measured 0.4487).
+    samples = [
+        _sample(["A"] * 2 + ["B"] * 6, ["g0"] * 8, [1.0] * 2 + [0.0] * 6),
+        _sample(["C"] * 2 + ["D"] * 6, ["g1"] * 8, [1.0] * 2 + [0.0] * 6),
+    ]
+    flat = torch.cat([s.info["reward"] for s in samples])
+    assert flat.mean().item() == pytest.approx(0.25)
+
+    per_rollout, per_group = _dedup_rollout_rewards(samples)
+    assert per_rollout.numel() == 4
+    assert per_group.numel() == 2
+    assert per_rollout.mean().item() == pytest.approx(0.5)
+    assert per_group.mean().item() == pytest.approx(0.5)
+
+
+def test_group_pass_rate_averages_within_group_first():
+    # One group solves 1 of 2 rollouts, the other solves 2 of 2. Per-rollout mean is 0.75;
+    # per-group mean is (0.5 + 1.0) / 2 = 0.75 here, but the group view is what eval reports,
+    # so keep both and let them differ when group sizes differ.
+    samples = [
+        _sample(["A", "B", "B"], ["g0"] * 3, [1.0, 0.0, 0.0]),
+        _sample(["C", "D"], ["g1"] * 2, [1.0, 1.0]),
+    ]
+    per_rollout, per_group = _dedup_rollout_rewards(samples)
+    assert per_rollout.numel() == 4
+    assert per_rollout.mean().item() == pytest.approx(0.75)
+    assert per_group.numel() == 2
+    assert per_group.mean().item() == pytest.approx(0.75)
+
+
+def test_single_turn_legacy_path_is_identity():
+    # No ids: every row is its own rollout, so dedup must not collapse anything.
+    s = types.SimpleNamespace()
+    s.info = {"reward": torch.tensor([1.0, 0.0, 1.0, 0.0])}
+    s.rollout_ids = None
+    s.group_ids = None
+    s.index = [0, 1, 2, 3]
+    per_rollout, _ = _dedup_rollout_rewards([s])
+    assert per_rollout.numel() == 4
+    assert per_rollout.mean().item() == pytest.approx(0.5)
+
+
+def test_samples_without_reward_are_skipped():
+    ok = _sample(["A"], ["g0"], [1.0])
+    missing = types.SimpleNamespace(info={}, rollout_ids=["B"], group_ids=["g1"], index=[0])
+    per_rollout, per_group = _dedup_rollout_rewards([ok, missing])
+    assert per_rollout.numel() == 1
+    assert per_group.numel() == 1
+
+
+def test_empty_input():
+    per_rollout, per_group = _dedup_rollout_rewards([])
+    assert per_rollout.numel() == 0
+    assert per_group.numel() == 0


### PR DESCRIPTION
…turn

rollout/reward_mean averaged the flattened rollout samples. A multi-turn rollout contributes one row per step it took and every row carries the same terminal reward, so the mean weighted each trajectory by its length.

That weighting is not neutral. A failing episode runs to the step cap while a successful one terminates as soon as it is done, so the trajectories that dominate the mean are systematically the zero-reward ones. On an OSWorld run the metric read 0.28 while the same checkpoint scored 0.4487 on the same 361 tasks through the eval path, which dedups by group id -- the whole gap was the weighting, not the policy. It also produced a -0.94 correlation between the reported reward and mean episode length, an artefact of the identity rather than a property of the run, which made the metric useless for judging whether training was making progress.

Merge by rollout id before averaging, following merge_rollout_rewards: rollout_ids when the agent stamps them, else group_ids, else the per-sample index. On the legacy single-turn path every row is already its own rollout, so the dedup is an identity and the reported number does not move.

Also report rollout/group_pass_rate -- the mean over prompt groups of that group's mean reward, which is exactly what compute_eval_metrics calls eval pass@1, so the training and eval numbers can finally be compared -- plus rollout/num_rollouts and rollout/num_prompt_groups next to the existing flattened rollout/num_samples, so the turn-per-rollout ratio that caused this is visible in the log.

Only the reported metrics change. Advantages already went through merge_rollout_rewards, which deduplicates by rollout id, so optimization is untouched.

response_length_mean and truncated_rate stay per turn: they are per-generation quantities and a per-rollout mean would not be meaningful.