### PR TITLE
fix(metrics): count a multi-turn rollout's reward once, not once per …

### DIFF
--- a/molt/trainer/rl_trainer.py
+++ b/molt/trainer/rl_trainer.py
@@ -15,6 +15,7 @@
 
 import asyncio
 import os
+import statistics
 import time
 from typing import Dict, Tuple
 
@@ -29,7 +30,7 @@ from molt.datasets.utils import blending_datasets
 from molt.trainer.algorithm.experience import balance_experiences
 from molt.trainer.algorithm.kl_controller import AdaptiveKLController, FixedKLController
 from molt.trainer.fsdp import FsdpStrategy
-from molt.trainer.rollout.experience_maker import RemoteExperienceMaker
+from molt.trainer.rollout.experience_maker import RemoteExperienceMaker, rollout_and_group_ids
 from molt.trainer.rollout.samples_generator import SamplesGenerator
 from molt.trainer.vllm.vllm_engine import batch_vllm_engine_call
 from molt.trainer.workers.actor_group import RayActorGroup
@@ -121,6 +122,35 @@ def prepare_datasets(strategy, tokenizer):
             * args.train.max_epochs
         )
     return prompts_dataloader, eval_dataloader, max_steps
+
+
+def _collect_rollout_rewards(rollout_samples):
+    """Regroup the flattened rollout rows back into rollouts and prompt groups.
+
+    A multi-turn rollout appears in ``rollout_samples`` once per step it took, and every one of
+    those rows carries the same terminal reward, so averaging the rows weights each trajectory by
+    its length. The weighting is not neutral: a failing episode runs to the step cap while a
+    successful one stops as soon as it is done, so the rows that dominate the mean are the
+    zero-reward ones. On an OSWorld run this read 0.28 where the same checkpoint scored 0.4487 on
+    the same tasks through the eval path, which groups before averaging.
+
+    Returns (one reward per rollout, one mean reward per prompt group).
+    """
+    reward_of_rollout: dict = {}  # every row of a rollout carries the same terminal reward
+    rewards_in_group: dict = {}
+    for sample in rollout_samples:
+        if "reward" not in sample.info:
+            continue
+        rollout_ids, group_ids = rollout_and_group_ids(sample)
+        sample_rewards = sample.info["reward"].flatten().tolist()
+        for rollout_id, group_id, reward in zip(rollout_ids, group_ids, sample_rewards, strict=True):
+            if rollout_id not in reward_of_rollout:
+                reward_of_rollout[rollout_id] = reward
+                rewards_in_group.setdefault(group_id, []).append(reward)
+    return (
+        list(reward_of_rollout.values()),
+        [statistics.fmean(rewards) for rewards in rewards_in_group.values()],
+    )
 
 
 def compute_eval_metrics(eval_dataloader, samples_list, n_samples_per_prompt):
@@ -326,15 +356,22 @@ class BaseRLTrainer:
         # Ground-truth rollout stats over the FULL generated set — from the lightweight fields present
         # on every rollout sample, and computed on `rollout_samples` (before balance_experiences drops
         # the trailing remainder), so num_samples and the means reflect everything we generated.
-        all_rewards = torch.cat([s.info["reward"] for s in rollout_samples if "reward" in s.info])
-        all_response_lengths = torch.cat([s.response_length for s in rollout_samples if s.response_length is not None])
-        all_truncated = torch.cat([s.truncated for s in rollout_samples if s.truncated is not None])
+        per_rollout, per_group = _collect_rollout_rewards(rollout_samples)
+        response_lengths = torch.cat([s.response_length for s in rollout_samples if s.response_length is not None])
+        truncated = torch.cat([s.truncated for s in rollout_samples if s.truncated is not None])
+        num_turn_rows = sum(s.info["reward"].numel() for s in rollout_samples if "reward" in s.info)
         rollout_stats = {
-            "rollout/reward_mean": all_rewards.float().mean().item(),
-            "rollout/reward_std": all_rewards.float().std().item() if len(all_rewards) > 1 else 0.0,
-            "rollout/response_length_mean": all_response_lengths.float().mean().item(),
-            "rollout/truncated_rate": all_truncated.float().mean().item(),
-            "rollout/num_samples": float(len(all_rewards)),
+            "rollout/reward_mean": statistics.fmean(per_rollout) if per_rollout else 0.0,
+            "rollout/reward_std": statistics.stdev(per_rollout) if len(per_rollout) > 1 else 0.0,
+            # Same name as eval's pass1 because it is the same quantity, on the same scale.
+            "rollout/pass1": statistics.fmean(per_group) if per_group else 0.0,
+            "rollout/num_rollouts": float(len(per_rollout)),
+            "rollout/num_prompt_groups": float(len(per_group)),
+            # Per turn rather than per rollout — these are per-generation quantities, and
+            # num_samples counts the flattened rows that sized the training batch.
+            "rollout/response_length_mean": response_lengths.float().mean().item(),
+            "rollout/truncated_rate": truncated.float().mean().item(),
+            "rollout/num_samples": float(num_turn_rows),
         }
 
         # Push the experiences to the actor shards (and the critic, which trains on the same batch

--- a/molt/trainer/rollout/experience_maker.py
+++ b/molt/trainer/rollout/experience_maker.py
@@ -39,6 +39,17 @@ if TYPE_CHECKING:
 logger = init_logger(__name__)
 
 
+def rollout_and_group_ids(experience):
+    """Per-sample rollout and prompt-group ids, with the fallbacks the pipeline shares.
+
+    Multi-turn agents stamp both. Legacy single-turn rollouts stamp neither, and there every
+    sample is its own rollout and its own group, so the sample index serves as both. Kept in one
+    place because every consumer that averages per rollout has to agree on it.
+    """
+    rollout_ids = experience.rollout_ids or list(experience.index)
+    return rollout_ids, (experience.group_ids or rollout_ids)
+
+
 class RemoteExperienceMaker:
     """Builds train-ready experiences from rollout samples and remote model forwards."""
 
@@ -152,10 +163,9 @@ class RemoteExperienceMaker:
             exp_len           = [3, 2]            # samples per experience, to re-split later
         """
         exp_len = [len(e.index) for e in experiences]
-        rollout_ids = list(itertools.chain.from_iterable(e.rollout_ids or list(e.index) for e in experiences))
-        group_ids = list(
-            itertools.chain.from_iterable(e.group_ids or e.rollout_ids or list(e.index) for e in experiences)
-        )
+        ids = [rollout_and_group_ids(e) for e in experiences]
+        rollout_ids = list(itertools.chain.from_iterable(r for r, _ in ids))
+        group_ids = list(itertools.chain.from_iterable(g for _, g in ids))
         rewards = torch.cat([e.rewards for e in experiences], dim=0)
         if not (len(rollout_ids) == len(group_ids) == rewards.numel()):
             raise ValueError(

--- a/tests/unit/test_collect_rollout_rewards.py
+++ b/tests/unit/test_collect_rollout_rewards.py
@@ -1,0 +1,81 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Rollout reward metrics must not weight a trajectory by how many turns it took."""
+import types
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from molt.trainer.rl_trainer import _collect_rollout_rewards
+from molt.trainer.rollout.experience_maker import rollout_and_group_ids
+
+
+def _sample(rollout_ids, group_ids, rewards):
+    return types.SimpleNamespace(
+        info={"reward": torch.tensor(rewards, dtype=torch.float)},
+        rollout_ids=rollout_ids,
+        group_ids=group_ids,
+        index=list(range(len(rewards))),
+    )
+
+
+def test_long_failures_do_not_outweigh_short_successes():
+    # Two groups, each a 2-turn success and a 6-turn failure. Flattened: 4/16 = 0.25.
+    # Honest pass rate: 2/4 = 0.5. That 2x is the bug, at the magnitude seen on OSWorld.
+    samples = [
+        _sample(["A"] * 2 + ["B"] * 6, ["g0"] * 8, [1.0] * 2 + [0.0] * 6),
+        _sample(["C"] * 2 + ["D"] * 6, ["g1"] * 8, [1.0] * 2 + [0.0] * 6),
+    ]
+    assert torch.cat([s.info["reward"] for s in samples]).mean().item() == pytest.approx(0.25)
+
+    per_rollout, per_group = _collect_rollout_rewards(samples)
+    assert per_rollout == [1.0, 0.0, 1.0, 0.0]
+    assert per_group == [0.5, 0.5]
+
+
+def test_a_rollout_split_across_samples_is_counted_once():
+    samples = [_sample(["A"], ["g0"], [1.0]), _sample(["A", "B"], ["g0", "g0"], [1.0, 0.0])]
+    per_rollout, per_group = _collect_rollout_rewards(samples)
+    assert per_rollout == [1.0, 0.0]
+    assert per_group == [0.5]
+
+
+def test_single_turn_legacy_path_is_an_identity():
+    # No ids stamped: every row is its own rollout and its own group.
+    sample = types.SimpleNamespace(
+        info={"reward": torch.tensor([1.0, 0.0, 1.0, 0.0])},
+        rollout_ids=None,
+        group_ids=None,
+        index=[0, 1, 2, 3],
+    )
+    per_rollout, per_group = _collect_rollout_rewards([sample])
+    assert per_rollout == [1.0, 0.0, 1.0, 0.0]
+    assert per_group == [1.0, 0.0, 1.0, 0.0]
+
+
+def test_samples_without_a_reward_are_skipped():
+    ok = _sample(["A"], ["g0"], [1.0])
+    missing = types.SimpleNamespace(info={}, rollout_ids=["B"], group_ids=["g1"], index=[0])
+    assert _collect_rollout_rewards([ok, missing]) == ([1.0], [1.0])
+
+
+def test_empty_input():
+    assert _collect_rollout_rewards([]) == ([], [])
+
+
+def test_id_length_mismatch_is_not_silently_truncated():
+    bad = _sample(["A", "B"], ["g0", "g0"], [1.0, 0.0, 1.0])
+    with pytest.raises(ValueError):
+        _collect_rollout_rewards([bad])
+
+
+def test_shared_id_fallbacks():
+    stamped = _sample(["A"], ["g0"], [1.0])
+    assert rollout_and_group_ids(stamped) == (["A"], ["g0"])
+
+    no_group = types.SimpleNamespace(rollout_ids=["A"], group_ids=None, index=[0])
+    assert rollout_and_group_ids(no_group) == (["A"], ["A"])
+
+    bare = types.SimpleNamespace(rollout_ids=None, group_ids=None, index=[7])
+    assert rollout_and_group_ids(bare) == ([7], [7])


### PR DESCRIPTION
…turn

rollout/reward_mean averaged the flattened rollout samples. A multi-turn rollout contributes one row per step it took and every row carries the same terminal reward, so the mean weighted each trajectory by its length.

That weighting is not neutral. A failing episode runs to the step cap while a successful one stops as soon as it is done, so the rows that dominate the mean are systematically the zero-reward ones. On an OSWorld run the metric read 0.28 while the same checkpoint scored 0.4487 on the same 361 tasks through the eval path, which groups before averaging -- the whole gap was the weighting. It also produced a -0.94 correlation between the reported reward and mean episode length, an artefact of the identity rather than a property of the run, which made the metric useless for judging whether training was progressing.

Group by rollout id before averaging. The id fallback chain moves into rollout_and_group_ids() so the metrics path and _merge_rollout_rewards cannot drift apart -- they have to agree on what a rollout is, and the first draft of this fix got the chain subtly wrong by writing it out a second time. On the legacy single-turn path neither id is stamped, so every row is its own rollout and the grouping is an identity: those runs report exactly what they did before.

Also report rollout/group_pass_rate, the mean over prompt groups of that group's mean reward, which is what compute_eval_metrics calls eval pass@1 -- so a training run and its evals are finally on the same scale -- plus rollout/num_rollouts and rollout/num_prompt_groups beside the flattened rollout/num_samples, making the turns-per-rollout ratio that caused this visible in the log.

Only reported metrics change. Advantages already went through _merge_rollout_rewards, which deduplicates by rollout id, so optimization is untouched.

response_length_mean and truncated_rate stay per turn: they are per-generation quantities and a per-rollout mean would not mean anything.