### PR TITLE
fix(fsdp): equalize packed tokens across expert ranks

### DIFF
--- a/molt/models/base.py
+++ b/molt/models/base.py
@@ -24,6 +24,7 @@ from pathlib import Path
 from typing import Optional, Union
 
 import torch
+import torch.distributed as dist
 import torch.nn as nn
 import torch.nn.functional as F
 
@@ -269,6 +270,7 @@ class BaseModel(nn.Module):
         self.temperature = temperature
         self.packing_samples = packing_samples
         self.device_mesh = device_mesh
+        self.moe_mesh = moe_mesh
         mesh_dims = getattr(device_mesh, "mesh_dim_names", ()) or ()
         cp_mesh = device_mesh["cp"] if device_mesh is not None and "cp" in mesh_dims else None
         self.cp_size = cp_mesh.size() if cp_mesh is not None else 1
@@ -544,7 +546,7 @@ class BaseModel(nn.Module):
             return unpack_to_padded(t, indices, batch, seqlen)
         return t
 
-    def _build_routing_targets(self, routed_experts, indices, cp_forward):
+    def _build_routing_targets(self, routed_experts, indices, cp_forward, packed_tokens=None):
         """Shard the R3 routing ids to this rank's forward token order (RouterReplay).
 
         ``routed_experts`` is ``(B, vllm_layers, topk, S)`` (rollout top-k expert ids per
@@ -573,6 +575,20 @@ class BaseModel(nn.Module):
             per_token = routing.permute(0, 3, 1, 2).reshape(b * s, n_layers, topk).long()
             if self.packing_samples:
                 per_token = per_token.index_select(0, indices)  # drop pad tokens for the packed order
+                if packed_tokens is not None:
+                    trailing_pad = int(packed_tokens) - per_token.shape[0]
+                    if trailing_pad < 0:
+                        raise ValueError(
+                            f"Packed model input has {packed_tokens} tokens but routing has "
+                            f"{per_token.shape[0]} real-token rows"
+                        )
+                    if trailing_pad:
+                        # HybridEP equalizes local token counts across its EP group.
+                        # Use an in-range placeholder because Gate gathers routing
+                        # weights before the expert path applies padding_mask. The
+                        # masked rows are then changed to -1 before dispatch.
+                        pad = per_token.new_zeros((trailing_pad, *per_token.shape[1:]))
+                        per_token = torch.cat((per_token, pad), dim=0)
         if per_token.shape[1] <= max(global_ids):
             raise ValueError(
                 f"rollout routing has {per_token.shape[1]} layers but a MoE gate maps to global "
@@ -612,8 +628,27 @@ class BaseModel(nn.Module):
             # cp1 real-token packing. CP is incompatible with packed sequences: cp>1
             # falls through to the padded branch, where the model-owned sharder
             # flattens the padded [B,S] batch to THD itself (from seq_lens).
+            pad_to_tokens = None
+            mesh_dims = getattr(self.moe_mesh, "mesh_dim_names", ()) or ()
+            if (
+                self.moe_mesh is not None
+                and "ep" in mesh_dims
+                and self.moe_mesh["ep"].size() > 1
+                and os.environ.get("MOLT_MOE_DISPATCHER", "hybridep").lower() == "hybridep"
+            ):
+                # HybridEP all-gathers a [local_tokens, num_experts] routing map.
+                # Packed RL responses have rank-local lengths, so equalize the token
+                # dimension within the exact EP group before entering the model.
+                local_tokens = attention_mask.sum(dtype=torch.int64)
+                dist.all_reduce(local_tokens, op=dist.ReduceOp.MAX, group=self.moe_mesh.get_group("ep"))
+                pad_to_tokens = int(local_tokens.item())
+            padding_token_id = getattr(getattr(self.model, "config", None), "pad_token_id", None)
             sequences, position_ids, rolled_sequences, indices, attn_kwargs = pack_padded_batch(
-                sequences, attention_mask, style=self._packing_style
+                sequences,
+                attention_mask,
+                style=self._packing_style,
+                pad_to_tokens=pad_to_tokens,
+                padding_token_id=padding_token_id if padding_token_id is not None else 0,
             )
             forward_attention_mask = None
         else:
@@ -769,7 +804,14 @@ class BaseModel(nn.Module):
         if routed_experts is not None:
             from nemo_automodel.components.moe.router_replay import RouterReplay
 
-            replay_ctx = RouterReplay.replay(self._build_routing_targets(routed_experts, indices, cp_forward))
+            replay_ctx = RouterReplay.replay(
+                self._build_routing_targets(
+                    routed_experts,
+                    indices,
+                    cp_forward,
+                    packed_tokens=sequences.numel() if self.packing_samples and not cp_forward else None,
+                )
+            )
             # Replay must stay active through the activation-checkpoint recompute in
             # backward, else the recompute reverts to the live router and disagrees with
             # the replayed forward (CheckpointError). Keep it on the caller's stack; the

--- a/molt/models/base.py
+++ b/molt/models/base.py
@@ -270,7 +270,16 @@ class BaseModel(nn.Module):
         self.temperature = temperature
         self.packing_samples = packing_samples
         self.device_mesh = device_mesh
-        self.moe_mesh = moe_mesh
+        # HybridEP all-gathers a [tokens, experts] routing map, so every rank in an EP
+        # group must pack the same token count. Other dispatchers don't shape-collect.
+        ep_dims = getattr(moe_mesh, "mesh_dim_names", ()) or ()
+        self._ep_pad_group = (
+            moe_mesh.get_group("ep")
+            if "ep" in ep_dims
+            and moe_mesh["ep"].size() > 1
+            and os.environ.get("MOLT_MOE_DISPATCHER", "hybridep").lower() == "hybridep"
+            else None
+        )
         mesh_dims = getattr(device_mesh, "mesh_dim_names", ()) or ()
         cp_mesh = device_mesh["cp"] if device_mesh is not None and "cp" in mesh_dims else None
         self.cp_size = cp_mesh.size() if cp_mesh is not None else 1
@@ -546,7 +555,7 @@ class BaseModel(nn.Module):
             return unpack_to_padded(t, indices, batch, seqlen)
         return t
 
-    def _build_routing_targets(self, routed_experts, indices, cp_forward, packed_tokens=None):
+    def _build_routing_targets(self, routed_experts, indices, cp_forward, pad_to_tokens=None):
         """Shard the R3 routing ids to this rank's forward token order (RouterReplay).
 
         ``routed_experts`` is ``(B, vllm_layers, topk, S)`` (rollout top-k expert ids per
@@ -575,20 +584,10 @@ class BaseModel(nn.Module):
             per_token = routing.permute(0, 3, 1, 2).reshape(b * s, n_layers, topk).long()
             if self.packing_samples:
                 per_token = per_token.index_select(0, indices)  # drop pad tokens for the packed order
-                if packed_tokens is not None:
-                    trailing_pad = int(packed_tokens) - per_token.shape[0]
-                    if trailing_pad < 0:
-                        raise ValueError(
-                            f"Packed model input has {packed_tokens} tokens but routing has "
-                            f"{per_token.shape[0]} real-token rows"
-                        )
-                    if trailing_pad:
-                        # HybridEP equalizes local token counts across its EP group.
-                        # Use an in-range placeholder because Gate gathers routing
-                        # weights before the expert path applies padding_mask. The
-                        # masked rows are then changed to -1 before dispatch.
-                        pad = per_token.new_zeros((trailing_pad, *per_token.shape[1:]))
-                        per_token = torch.cat((per_token, pad), dim=0)
+                if pad_to_tokens is not None:
+                    # Match the EP-equalized pack. Expert 0, not the -1 sentinel: Gate
+                    # gathers routing weights before padding_mask drops these rows.
+                    per_token = F.pad(per_token, (0, 0, 0, 0, 0, pad_to_tokens - per_token.shape[0]))
         if per_token.shape[1] <= max(global_ids):
             raise ValueError(
                 f"rollout routing has {per_token.shape[1]} layers but a MoE gate maps to global "
@@ -620,6 +619,7 @@ class BaseModel(nn.Module):
         batch, seqlen = sequences.size()
         attn_kwargs: dict = {}
         indices = None
+        pad_to_tokens = None  # set under EP-equalized packing; also pads the routing rows
         cp_forward = False
         cp_ctx_factory = nullcontext
         cp_batch = None  # built in the packed or padded branch below; None => no CP sharding
@@ -628,27 +628,14 @@ class BaseModel(nn.Module):
             # cp1 real-token packing. CP is incompatible with packed sequences: cp>1
             # falls through to the padded branch, where the model-owned sharder
             # flattens the padded [B,S] batch to THD itself (from seq_lens).
-            pad_to_tokens = None
-            mesh_dims = getattr(self.moe_mesh, "mesh_dim_names", ()) or ()
-            if (
-                self.moe_mesh is not None
-                and "ep" in mesh_dims
-                and self.moe_mesh["ep"].size() > 1
-                and os.environ.get("MOLT_MOE_DISPATCHER", "hybridep").lower() == "hybridep"
-            ):
-                # HybridEP all-gathers a [local_tokens, num_experts] routing map.
-                # Packed RL responses have rank-local lengths, so equalize the token
-                # dimension within the exact EP group before entering the model.
-                local_tokens = attention_mask.sum(dtype=torch.int64)
-                dist.all_reduce(local_tokens, op=dist.ReduceOp.MAX, group=self.moe_mesh.get_group("ep"))
-                pad_to_tokens = int(local_tokens.item())
-            padding_token_id = getattr(getattr(self.model, "config", None), "pad_token_id", None)
+            if self._ep_pad_group is not None:
+                # Packed RL responses have rank-local token counts; grow them all to the
+                # EP-group max so HybridEP's routing-map all-gather agrees on the shape.
+                local_tokens = attention_mask.count_nonzero()
+                dist.all_reduce(local_tokens, op=dist.ReduceOp.MAX, group=self._ep_pad_group)
+                pad_to_tokens = int(local_tokens)
             sequences, position_ids, rolled_sequences, indices, attn_kwargs = pack_padded_batch(
-                sequences,
-                attention_mask,
-                style=self._packing_style,
-                pad_to_tokens=pad_to_tokens,
-                padding_token_id=padding_token_id if padding_token_id is not None else 0,
+                sequences, attention_mask, style=self._packing_style, pad_to_tokens=pad_to_tokens
             )
             forward_attention_mask = None
         else:
@@ -804,14 +791,8 @@ class BaseModel(nn.Module):
         if routed_experts is not None:
             from nemo_automodel.components.moe.router_replay import RouterReplay
 
-            replay_ctx = RouterReplay.replay(
-                self._build_routing_targets(
-                    routed_experts,
-                    indices,
-                    cp_forward,
-                    packed_tokens=sequences.numel() if self.packing_samples and not cp_forward else None,
-                )
-            )
+            targets = self._build_routing_targets(routed_experts, indices, cp_forward, pad_to_tokens)
+            replay_ctx = RouterReplay.replay(targets)
             # Replay must stay active through the activation-checkpoint recompute in
             # backward, else the recompute reverts to the live router and disagrees with
             # the replayed forward (CheckpointError). Keep it on the caller's stack; the

--- a/molt/trainer/fsdp/packing.py
+++ b/molt/trainer/fsdp/packing.py
@@ -28,6 +28,7 @@ from typing import Any
 
 import torch
 import torch.distributed as dist
+import torch.nn.functional as F
 from torch.distributed.tensor import DTensor
 
 
@@ -72,7 +73,6 @@ def pack_padded_batch(
     *,
     style: str = "hf",
     pad_to_tokens: int | None = None,
-    padding_token_id: int = 0,
 ):
     """Convert a padded `(B, S)` batch to packed `(1, total_real_tokens)` format.
 
@@ -83,11 +83,9 @@ def pack_padded_batch(
         indices:          flat indices into `(B*S,)` of real tokens (for `unpack_to_padded`)
         attn_kwargs:      HF FlashAttention kwargs or AutoModel THD kwargs
 
-    ``pad_to_tokens`` appends synthetic tokens to the final packed sequence. This is
-    used by HybridEP, whose routing-map all-gather requires every rank in an EP group
-    to contribute the same ``[tokens, experts]`` shape. The synthetic suffix is causal
-    (so real tokens cannot attend to it), is marked in AutoModel's ``padding_mask`` so
-    it is not routed to experts, and is dropped by :func:`unpack_to_padded`.
+    ``pad_to_tokens`` extends the last packed sequence with synthetic tokens so EP ranks
+    agree on the token count. They are causal-suffixed (real outputs unchanged), flagged
+    in ``padding_mask`` so experts skip them, and dropped by :func:`unpack_to_padded`.
     """
     if style not in {"hf", "automodel"}:
         raise ValueError(f"Unsupported packing style: {style}")
@@ -112,33 +110,18 @@ def pack_padded_batch(
     position_ids = position_ids_full.reshape(batch * seqlen).index_select(0, indices).unsqueeze(0)
 
     real_tokens = int(indices.numel())
-    target_tokens = real_tokens if pad_to_tokens is None else int(pad_to_tokens)
-    if target_tokens < real_tokens:
-        raise ValueError(f"pad_to_tokens ({target_tokens}) must be >= real token count ({real_tokens})")
-    trailing_pad = target_tokens - real_tokens
+    trailing_pad = 0 if pad_to_tokens is None else pad_to_tokens - real_tokens
     if trailing_pad:
-        token_pad = torch.full(
-            (1, trailing_pad),
-            padding_token_id,
-            dtype=packed_ids.dtype,
-            device=packed_ids.device,
-        )
-        packed_ids = torch.cat((packed_ids, token_pad), dim=1)
-        rolled_packed = torch.cat((rolled_packed, token_pad), dim=1)
-
-        # Treat the synthetic suffix as part of the final causal sequence. Real
-        # positions precede it, so their attention outputs remain unchanged.
-        last_real_length = int(seq_lens[-1].item()) if seq_lens.numel() else 0
-        pad_positions = torch.arange(
-            last_real_length,
-            last_real_length + trailing_pad,
-            dtype=position_ids.dtype,
-            device=position_ids.device,
-        ).unsqueeze(0)
-        position_ids = torch.cat((position_ids, pad_positions), dim=1)
+        # Token ids are arbitrary (these rows are masked and then dropped); the
+        # positions continue the last sequence so real tokens never attend to them.
+        last_len = int(seq_lens[-1])
+        packed_ids = F.pad(packed_ids, (0, trailing_pad))
+        rolled_packed = F.pad(rolled_packed, (0, trailing_pad))
+        pad_positions = torch.arange(last_len, last_len + trailing_pad, device=position_ids.device)
+        position_ids = torch.cat((position_ids, pad_positions.to(position_ids.dtype).unsqueeze(0)), dim=1)
         cu_seq_lens = cu_seq_lens.clone()
         cu_seq_lens[-1] += trailing_pad
-        max_length = max(max_length, last_real_length + trailing_pad)
+        max_length = max(max_length, last_len + trailing_pad)
 
     if style == "automodel":
         attn_kwargs = {
@@ -148,9 +131,8 @@ def pack_padded_batch(
             "max_seqlen": int(max_length),
         }
         if trailing_pad:
-            padding_mask = torch.zeros((1, target_tokens), dtype=torch.bool, device=sequences.device)
-            padding_mask[:, real_tokens:] = True
-            attn_kwargs["padding_mask"] = padding_mask
+            is_pad = torch.arange(real_tokens + trailing_pad, device=sequences.device) >= real_tokens
+            attn_kwargs["padding_mask"] = is_pad.unsqueeze(0)
     else:
         attn_kwargs = {
             "cu_seq_lens_q": cu_seq_lens,
@@ -168,14 +150,8 @@ def unpack_to_padded(packed: torch.Tensor, indices: torch.Tensor, batch: int, se
     using the `indices` from the original pack.
     """
     packed_values = packed.squeeze(0) if packed.dim() > 1 and packed.shape[0] == 1 else packed
-    real_tokens = int(indices.numel())
-    if packed_values.shape[0] < real_tokens:
-        raise ValueError(
-            f"Packed output has {packed_values.shape[0]} tokens, fewer than the {real_tokens} real-token indices"
-        )
-    # HybridEP equalization may append a synthetic suffix. It has no destination
-    # in the caller's original padded [B, S] coordinates and must be discarded.
-    packed_values = packed_values[:real_tokens]
+    # An EP-equalized pack carries a synthetic suffix with no [B, S] destination.
+    packed_values = packed_values[: indices.numel()]
     output = packed_values.new_zeros((batch * seqlen, *packed_values.shape[1:]))
     output.index_copy_(0, indices, packed_values)
     return output.view(batch, seqlen, *packed_values.shape[1:])

--- a/molt/trainer/fsdp/packing.py
+++ b/molt/trainer/fsdp/packing.py
@@ -66,7 +66,14 @@ def is_automodel_custom_model(model: Any) -> bool:
     return False
 
 
-def pack_padded_batch(sequences: torch.Tensor, attention_mask: torch.Tensor, *, style: str = "hf"):
+def pack_padded_batch(
+    sequences: torch.Tensor,
+    attention_mask: torch.Tensor,
+    *,
+    style: str = "hf",
+    pad_to_tokens: int | None = None,
+    padding_token_id: int = 0,
+):
     """Convert a padded `(B, S)` batch to packed `(1, total_real_tokens)` format.
 
     Returns:
@@ -75,6 +82,12 @@ def pack_padded_batch(sequences: torch.Tensor, attention_mask: torch.Tensor, *, 
         rolled_input_ids: `(1, total_real_tokens)` from `torch.roll(input_ids, -1)` then unpadded
         indices:          flat indices into `(B*S,)` of real tokens (for `unpack_to_padded`)
         attn_kwargs:      HF FlashAttention kwargs or AutoModel THD kwargs
+
+    ``pad_to_tokens`` appends synthetic tokens to the final packed sequence. This is
+    used by HybridEP, whose routing-map all-gather requires every rank in an EP group
+    to contribute the same ``[tokens, experts]`` shape. The synthetic suffix is causal
+    (so real tokens cannot attend to it), is marked in AutoModel's ``padding_mask`` so
+    it is not routed to experts, and is dropped by :func:`unpack_to_padded`.
     """
     if style not in {"hf", "automodel"}:
         raise ValueError(f"Unsupported packing style: {style}")
@@ -98,6 +111,35 @@ def pack_padded_batch(sequences: torch.Tensor, attention_mask: torch.Tensor, *, 
     position_ids_full = torch.clip(torch.cumsum(attention_mask, dim=-1) - 1, min=0)
     position_ids = position_ids_full.reshape(batch * seqlen).index_select(0, indices).unsqueeze(0)
 
+    real_tokens = int(indices.numel())
+    target_tokens = real_tokens if pad_to_tokens is None else int(pad_to_tokens)
+    if target_tokens < real_tokens:
+        raise ValueError(f"pad_to_tokens ({target_tokens}) must be >= real token count ({real_tokens})")
+    trailing_pad = target_tokens - real_tokens
+    if trailing_pad:
+        token_pad = torch.full(
+            (1, trailing_pad),
+            padding_token_id,
+            dtype=packed_ids.dtype,
+            device=packed_ids.device,
+        )
+        packed_ids = torch.cat((packed_ids, token_pad), dim=1)
+        rolled_packed = torch.cat((rolled_packed, token_pad), dim=1)
+
+        # Treat the synthetic suffix as part of the final causal sequence. Real
+        # positions precede it, so their attention outputs remain unchanged.
+        last_real_length = int(seq_lens[-1].item()) if seq_lens.numel() else 0
+        pad_positions = torch.arange(
+            last_real_length,
+            last_real_length + trailing_pad,
+            dtype=position_ids.dtype,
+            device=position_ids.device,
+        ).unsqueeze(0)
+        position_ids = torch.cat((position_ids, pad_positions), dim=1)
+        cu_seq_lens = cu_seq_lens.clone()
+        cu_seq_lens[-1] += trailing_pad
+        max_length = max(max_length, last_real_length + trailing_pad)
+
     if style == "automodel":
         attn_kwargs = {
             "qkv_format": "thd",
@@ -105,6 +147,10 @@ def pack_padded_batch(sequences: torch.Tensor, attention_mask: torch.Tensor, *, 
             "cu_seqlens_padded": cu_seq_lens,
             "max_seqlen": int(max_length),
         }
+        if trailing_pad:
+            padding_mask = torch.zeros((1, target_tokens), dtype=torch.bool, device=sequences.device)
+            padding_mask[:, real_tokens:] = True
+            attn_kwargs["padding_mask"] = padding_mask
     else:
         attn_kwargs = {
             "cu_seq_lens_q": cu_seq_lens,
@@ -122,6 +168,14 @@ def unpack_to_padded(packed: torch.Tensor, indices: torch.Tensor, batch: int, se
     using the `indices` from the original pack.
     """
     packed_values = packed.squeeze(0) if packed.dim() > 1 and packed.shape[0] == 1 else packed
+    real_tokens = int(indices.numel())
+    if packed_values.shape[0] < real_tokens:
+        raise ValueError(
+            f"Packed output has {packed_values.shape[0]} tokens, fewer than the {real_tokens} real-token indices"
+        )
+    # HybridEP equalization may append a synthetic suffix. It has no destination
+    # in the caller's original padded [B, S] coordinates and must be discarded.
+    packed_values = packed_values[:real_tokens]
     output = packed_values.new_zeros((batch * seqlen, *packed_values.shape[1:]))
     output.index_copy_(0, indices, packed_values)
     return output.view(batch, seqlen, *packed_values.shape[1:])

--- a/tests/unit/test_cp_thd_packing.py
+++ b/tests/unit/test_cp_thd_packing.py
@@ -35,6 +35,7 @@ import pytest
 import torch
 
 from molt.models.base import BaseModel
+from molt.trainer.fsdp.packing import pack_padded_batch, unpack_to_padded
 
 
 def test_restore_cp_gathers_to_bs_and_drops_cp_pad():
@@ -66,6 +67,31 @@ def test_restore_packing_cp1_scatters_to_bs():
     out = BaseModel._restore_full_sequence(stub, packed, cp_forward=False, batch=B, seqlen=S, indices=indices)
     assert out.shape == (B, S)
     assert out.reshape(-1).tolist() == [1.0, 2.0, 0.0, 3.0, 4.0, 5.0]
+
+
+def test_ep_equalized_packing_masks_and_drops_synthetic_suffix():
+    sequences = torch.tensor([[10, 11, 0, 0], [20, 21, 22, 0]])
+    attention_mask = torch.tensor([[1, 1, 0, 0], [1, 1, 1, 0]])
+
+    packed, positions, _rolled, indices, kwargs = pack_padded_batch(
+        sequences,
+        attention_mask,
+        style="automodel",
+        pad_to_tokens=8,
+        padding_token_id=99,
+    )
+
+    assert packed.tolist() == [[10, 11, 20, 21, 22, 99, 99, 99]]
+    assert positions.tolist() == [[0, 1, 0, 1, 2, 3, 4, 5]]
+    assert kwargs["cu_seqlens"].tolist() == [0, 2, 8]
+    assert kwargs["cu_seqlens_padded"].tolist() == [0, 2, 8]
+    assert kwargs["max_seqlen"] == 6
+    assert kwargs["padding_mask"].tolist() == [[False, False, False, False, False, True, True, True]]
+
+    # Model-side outputs include the synthetic suffix, but restore scatters only
+    # the five original real-token rows back into [B, S].
+    restored = unpack_to_padded(torch.arange(1, 9).view(1, 8), indices, batch=2, seqlen=4)
+    assert restored.tolist() == [[1, 2, 0, 0], [3, 4, 5, 0]]
 
 
 class _FakeMesh:  # single-process stand-in; make_* reads size() + get_group()

--- a/tests/unit/test_cp_thd_packing.py
+++ b/tests/unit/test_cp_thd_packing.py
@@ -74,14 +74,10 @@ def test_ep_equalized_packing_masks_and_drops_synthetic_suffix():
     attention_mask = torch.tensor([[1, 1, 0, 0], [1, 1, 1, 0]])
 
     packed, positions, _rolled, indices, kwargs = pack_padded_batch(
-        sequences,
-        attention_mask,
-        style="automodel",
-        pad_to_tokens=8,
-        padding_token_id=99,
+        sequences, attention_mask, style="automodel", pad_to_tokens=8
     )
 
-    assert packed.tolist() == [[10, 11, 20, 21, 22, 99, 99, 99]]
+    assert packed.tolist() == [[10, 11, 20, 21, 22, 0, 0, 0]]
     assert positions.tolist() == [[0, 1, 0, 1, 2, 3, 4, 5]]
     assert kwargs["cu_seqlens"].tolist() == [0, 2, 8]
     assert kwargs["cu_seqlens_padded"].tolist() == [0, 2, 8]

--- a/tests/unit/test_routing_replay.py
+++ b/tests/unit/test_routing_replay.py
@@ -223,11 +223,7 @@ def test_build_routing_targets_pads_hybridep_suffix_with_valid_masked_expert():
     stub = SimpleNamespace(packing_samples=True, _num_routing_gates=L, _moe_layer_global_ids=list(range(L)))
     # Only tokens 0 and 1 are real on this rank; HybridEP equalizes it to four.
     targets = BaseModel._build_routing_targets(
-        stub,
-        routed,
-        indices=torch.tensor([0, 1]),
-        cp_forward=False,
-        packed_tokens=4,
+        stub, routed, indices=torch.tensor([0, 1]), cp_forward=False, pad_to_tokens=4
     )
 
     for layer in range(L):

--- a/tests/unit/test_routing_replay.py
+++ b/tests/unit/test_routing_replay.py
@@ -215,6 +215,27 @@ def test_build_routing_targets_preserves_minus_one_sentinel():
         assert targets[layer][1:, 0].tolist() == [10 * layer + 1, 10 * layer + 2]
 
 
+def test_build_routing_targets_pads_hybridep_suffix_with_valid_masked_expert():
+    routed = torch.zeros(1, L, K, 3, dtype=torch.int16)
+    for layer in range(L):
+        routed[0, layer, 0] = torch.tensor([10 * layer, 10 * layer + 1, 10 * layer + 2])
+
+    stub = SimpleNamespace(packing_samples=True, _num_routing_gates=L, _moe_layer_global_ids=list(range(L)))
+    # Only tokens 0 and 1 are real on this rank; HybridEP equalizes it to four.
+    targets = BaseModel._build_routing_targets(
+        stub,
+        routed,
+        indices=torch.tensor([0, 1]),
+        cp_forward=False,
+        packed_tokens=4,
+    )
+
+    for layer in range(L):
+        assert targets[layer].shape == (4, K)
+        assert targets[layer][:2, 0].tolist() == [10 * layer, 10 * layer + 1]
+        assert (targets[layer][2:] == 0).all()
+
+
 def test_make_experience_batch_mixed_none_routed_experts():
     # A batch mixing a captured-routing sample with an unrouted (None) one must neither
     # silently drop the batch's routing (leading None -> first-item dispatch returned None)


### PR DESCRIPTION
## What changed

- compute the maximum packed token count inside the exact MoE expert-parallel group when CP=1 packing is used with HybridEP
- append a causal synthetic suffix so every expert rank contributes the same `[tokens, experts]` routing-map shape
- pass AutoModel's `padding_mask` so synthetic tokens are excluded from expert routing, pad routing-replay targets consistently, and trim the suffix during unpack
- add focused coverage for packed padding/unpack and routing-target masking

## Why

Molt RL removes per-sample padding before packing dynamically generated experiences. The resulting real-token count can differ across expert ranks. HybridEP all-gathers rank-local routing maps, so mismatched token dimensions can stall the collective and eventually surface as an NCCL timeout.

The fix adds only a scalar `MAX` all-reduce in the MoE EP group. It does not all-gather token tensors. Unlike fixed-length SFT padding, it pads each RL batch only to that batch's EP-group maximum.

## Impact

This enables variable-length packed RL training with HybridEP without changing the real-token outputs or loss. The behavior is guarded to CP=1, HybridEP, and MoE EP size greater than one; other packing and dispatcher paths are unchanged.

Related to #61, which covers fixed-length SFT data rather than dynamically packed RL experiences.

## Validation

- `ruff check molt/models/base.py molt/trainer/fsdp/packing.py tests/unit/test_cp_thd_packing.py tests/unit/test_routing_replay.py`
- `python -m pytest tests/unit/test_cp_thd_packing.py tests/unit/test_routing_replay.py -q` in the Molt GLM runtime container: **19 passed**
- GLM-5.2 HybridEP validation: variable-length EP8 forward/backward/optimizer smoke passed; an EP256 RL soak completed 10 steps without NCCL timeout at PR creation
