### PR TITLE
docs: move the working rules to AGENTS.md, import them from CLAUDE.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,31 @@
+# Molt — working rules for AI assistants
+
+## Code standards (hard rules, not preferences)
+
+The priority order is explicit: **human readability comes first; coding-agent
+traceability is the minimum gate.** A human should understand code in one pass,
+and an agent must be able to trace a feature from CLI flag to executed branch,
+tensor/record, metric, and test without reconstructing hidden control flow.
+
+1. Over-complex or hard-to-follow code is a **bug**, not a style issue.
+2. Reduce complexity and line count — prefer deleting code over adding it.
+3. No over-encapsulation: a helper needs 3+ real call sites AND nontrivial
+   logic; never wrap trivial code or add classes/files for one call site.
+4. Do NOT remove features, performance knobs, or observability in the name
+   of simplicity — knobs default ON stay ON.
+5. A "bug" that cannot trigger under the shipped recipes is not worth fixing.
+
+Details: `.claude/skills/simplicity-first` (invoke before any code change).
+
+## Comments
+
+Concise "why" only, 2-4 lines, written for an external reader: no job ids,
+commit hashes, single-run metrics, or internal cluster paths; keep upstream
+issue/PR links.
+
+## Workflow
+
+- Reviews report findings only; fixes ship as one minimal diff per issue
+  after approval.
+- Verify with `python -m compileall -q molt examples/python tests` and
+  `python -m pytest -q`; shell scripts with `bash -n`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,31 +1,8 @@
-# Molt — working rules for AI assistants
+@AGENTS.md
 
-## Code standards (hard rules, not preferences)
-
-The priority order is explicit: **human readability comes first; coding-agent
-traceability is the minimum gate.** A human should understand code in one pass,
-and an agent must be able to trace a feature from CLI flag to executed branch,
-tensor/record, metric, and test without reconstructing hidden control flow.
-
-1. Over-complex or hard-to-follow code is a **bug**, not a style issue.
-2. Reduce complexity and line count — prefer deleting code over adding it.
-3. No over-encapsulation: a helper needs 3+ real call sites AND nontrivial
-   logic; never wrap trivial code or add classes/files for one call site.
-4. Do NOT remove features, performance knobs, or observability in the name
-   of simplicity — knobs default ON stay ON.
-5. A "bug" that cannot trigger under the shipped recipes is not worth fixing.
-
-Details: `.claude/skills/simplicity-first` (invoke before any code change).
-
-## Comments
-
-Concise "why" only, 2-4 lines, written for an external reader: no job ids,
-commit hashes, single-run metrics, or internal cluster paths; keep upstream
-issue/PR links.
-
-## Workflow
-
-- Reviews report findings only; fixes ship as one minimal diff per issue
-  after approval.
-- Verify with `python -m compileall -q molt examples/python tests` and
-  `python -m pytest -q`; shell scripts with `bash -n`.
+<!--
+The working rules live in AGENTS.md so every coding agent reads the same file
+(Codex and friends look for AGENTS.md; Claude Code only looks for CLAUDE.md).
+This file exists purely to import it. Put Claude-specific instructions below
+the import, and everything tool-agnostic in AGENTS.md.
+-->


### PR DESCRIPTION
AGENTS.md is the cross-agent convention (Codex and others look for it), but Claude Code reads CLAUDE.md and nothing else, so a straight rename would have left it with no project instructions at all. Keep the rules in AGENTS.md and reduce CLAUDE.md to a one-line `@AGENTS.md` import, which Claude Code expands at session start. Both tools now read the same file, with no duplicated copy to drift.

Preferred over a `ln -s AGENTS.md CLAUDE.md` symlink: symlinks need Administrator or Developer Mode on Windows, and the import leaves a place to put Claude-specific instructions later without touching the shared rules.