### PR TITLE
fix(rollout): actually pass SPREAD when placing agent runners

### DIFF
--- a/molt/trainer/rl_trainer.py
+++ b/molt/trainer/rl_trainer.py
@@ -632,8 +632,20 @@ class GenerateSamplesActor:
         from molt.trainer.rollout.router import AgentRunnerActor
 
         num_runners = max(1, getattr(strategy.args.rollout, "num_runners", 2))
+        # SPREAD the runners across the cluster. AgentRunnerActor already asks for num_cpus=1 so
+        # that Ray *can* balance it, and the comment on that decorator assumes SPREAD is in
+        # effect -- but nothing ever passed it, and Ray's default packs onto the first node with
+        # room. A node with dozens of free CPUs has room for every runner, so all of them land
+        # there, and so do all of their desktop-env VMs.
+        #
+        # Measured on an OSWorld run: every AgentRunnerActor reported the same ip, putting 128
+        # containers on one node. That node hands out 128 x 4 ports from the provider's ranges,
+        # which is where port collisions begin; osworld_error climbed 4% -> 54% within eleven
+        # steps while mean episode length fell 63 -> 19, i.e. rollouts dying at setup.
         agent_runners = [
-            AgentRunnerActor.remote(strategy.args.train.agent_path, router_url, model_path=pretrain)
+            AgentRunnerActor.options(scheduling_strategy="SPREAD").remote(
+                strategy.args.train.agent_path, router_url, model_path=pretrain
+            )
             for _ in range(num_runners)
         ]
         ray.get([r.ready.remote() for r in agent_runners])


### PR DESCRIPTION
AgentRunnerActor reserves num_cpus=1, and the comment on that decorator explains the reason as "1 CPU/runner lets Ray spread them evenly across nodes" -- but no call site ever passed scheduling_strategy, so the placement was Ray's default, which packs onto the first node with capacity. Reserving a CPU only makes an actor schedulable; it does not make Ray spread it. A node with dozens of free CPUs has room for every runner, so every runner lands there.

For a plain CPU actor that is merely unbalanced. For this one it is not: each runner drives a desktop-env VM, so packing the runners packs the containers too. On an OSWorld run every AgentRunnerActor reported the same ip -- 128 containers on a single node, each allocating four host ports out of the provider's ranges. osworld_error rose 4% -> 54% over eleven steps while mean episode length fell 63 -> 19, the signature of rollouts dying during setup rather than the policy behaving badly. Those rollouts still score 0 and still produce gradients, so the run is not merely slower, it is training on noise.

SPREAD places them round-robin and degrades gracefully when a node is lost, which is what the num_cpus=1 comment intended all along.