### PR TITLE
chore(deps): bump nemo-automodel a3aa09bc -> 518ea280

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ einops
 grpcio>=1.74.0
 huggingface_hub>=1.0.0
 jsonlines
-nemo-automodel @ git+https://github.com/NVIDIA-NeMo/Automodel.git@a3aa09bcc6f141457dce3a519465d46849838688
+nemo-automodel @ git+https://github.com/NVIDIA-NeMo/Automodel.git@518ea28045a3bd0ff8591820082db0ddf222c481
 optree>=0.15.0
 packaging
 peft


### PR DESCRIPTION
80 commits of AutoModel main (2026-07-25 -> 2026-08-03). Verified before bumping:

- API surface: every nemo_automodel symbol molt imports is intact on the new commit. ContextParallelSharder and moe.router_replay (R3) — molt's most intricate usages — are untouched across the range; Checkpointer, CheckpointingConfig, FSDP2Config, ModelRegistry, scale_grads_and_clip_grad_norm and the rest keep the exact fields/signatures molt passes (config.py gained only optional multimodal fields; the one rename, consolidate_on_all_ranks, is a param molt never passes). No molt code change needed.
- Transitive pins unchanged: transformers==5.12.1, torch>=2.6.0, transformer-engine>=2.14.1, flash-linear-attention>=0.4.2 are identical between the old and new commit, so the container's existing floors still hold.

Not yet validated: numerical behaviour (routing / CP) can drift even with matching APIs. Rebuild the image and run the qwen3.6 vllm_kl check (25->50 steps) before merging.