### PR TITLE
feat(experience): pack microbatches at collate time via AutoModel's THD helper

### DIFF
--- a/molt/models/actor.py
+++ b/molt/models/actor.py
@@ -44,6 +44,7 @@ class Actor(BaseModel):
         cp_context_stack=None,
         return_entropy=False,
         routed_experts: Optional[torch.Tensor] = None,
+        seq_lens: Optional[list] = None,
         **mm_inputs,
     ) -> _AttrDict:
         """Run the policy forward and return one named output dict.
@@ -57,8 +58,14 @@ class Actor(BaseModel):
         - ``entropy``:          ``[B, S-1]`` — only when ``return_entropy`` (RL).
         - ``aux_loss``:         MoE load-balancing loss — only for NeMo custom MoE.
         """
-        output, rolled_sequences, cp_forward, indices, batch, seqlen = self._forward_backbone(
-            sequences, attention_mask, position_ids, cp_context_stack, mm_inputs, routed_experts=routed_experts
+        output, rolled_sequences, cp_forward, batch, seqlen = self._forward_backbone(
+            sequences,
+            attention_mask,
+            position_ids,
+            cp_context_stack,
+            mm_inputs,
+            routed_experts=routed_experts,
+            seq_lens=seq_lens,
         )
         logits = output["logits"]
         full_logits = None
@@ -80,10 +87,8 @@ class Actor(BaseModel):
             # entropy is seq-local even under TP+CP (unshard_dtensor only
             # collapses the TP vocab dim), so restore the full sequence axis the
             # same way as log_probs below.
-            entropy = self._restore_full_sequence(
-                entropy, cp_forward=cp_forward, batch=batch, seqlen=seqlen, indices=indices
-            )
-            output["entropy"] = entropy[:, :-1]
+            entropy = self._restore_full_sequence(entropy, cp_forward=cp_forward, batch=batch, seqlen=seqlen)
+            output["entropy"] = entropy if seq_lens is not None else entropy[:, :-1]
 
         if isinstance(logits, DTensor):
             log_probs = log_probs_from_vocab_parallel_logits(
@@ -98,14 +103,12 @@ class Actor(BaseModel):
             log_probs_input = logits if (cp_forward or full_logits is None) else full_logits
             log_probs = log_probs_from_logits(log_probs_input, rolled_sequences, temperature=self.temperature)
 
-        log_probs = self._restore_full_sequence(
-            log_probs, cp_forward=cp_forward, batch=batch, seqlen=seqlen, indices=indices
-        )
+        log_probs = self._restore_full_sequence(log_probs, cp_forward=cp_forward, batch=batch, seqlen=seqlen)
 
         # Drop the final column: logits[t] predicts token[t+1], so the last
         # position has no target. log_probs / action_log_probs / entropy are all
         # shifted [:, :-1] and stay mutually aligned.
-        output["log_probs"] = log_probs[:, :-1]
+        output["log_probs"] = log_probs if seq_lens is not None else log_probs[:, :-1]
 
         # RL / reference (action_mask given) additionally expose the action-span
         # log-probs, zeroed outside the generated tokens.

--- a/molt/models/base.py
+++ b/molt/models/base.py
@@ -30,8 +30,7 @@ import torch.nn.functional as F
 
 from molt.trainer.fsdp.packing import (
     is_automodel_custom_model,
-    pack_padded_batch,
-    unpack_to_padded,
+    packed_attn_kwargs,
 )
 
 from .utils import (
@@ -521,12 +520,13 @@ class BaseModel(nn.Module):
                 self._vlm_config, "video_token_id", "video_token_index", "video_context_token_id"
             )
 
-    def _restore_full_sequence(self, t, *, cp_forward, batch, seqlen, indices):
-        """Map a per-token tensor back onto the full ``[B, seqlen]`` axis.
+    def _restore_full_sequence(self, t, *, cp_forward, batch, seqlen):
+        """Map a per-token tensor back onto the caller's token axis.
 
-        Inverts whichever seq-axis transform the forward applied (they are mutually
-        exclusive): CP sharding under cp>1, or real-token packing under cp1. No-op
-        when neither is active.
+        Under cp>1 this gathers the CP shards back to ``[B, seqlen]``. A packed
+        batch needs no inverse: it keeps the flat ``[1, total]`` axis that its
+        per-token inputs already share, and ``packed_seq_lens`` splits it per
+        sample wherever a caller needs sequence boundaries.
         """
         if cp_forward:
             # Differentiable all-gather of this rank's CP shard back to the caller's
@@ -534,12 +534,9 @@ class BaseModel(nn.Module):
             # reshape for THD input_row_shape). The trailing slice drops the
             # cp-multiple pad the forward added.
             return self._cp_sharder.gather_token_tensor(t, seq_dim=1, trim=True, fill=0.0)[:, :seqlen]
-        if self.packing_samples:
-            # cp1 packing: scatter the packed [1, total] rows back to padded [B, seqlen].
-            return unpack_to_padded(t, indices, batch, seqlen)
         return t
 
-    def _build_routing_targets(self, routed_experts, indices, cp_forward, pad_to_tokens=None):
+    def _build_routing_targets(self, routed_experts, cp_forward, pad_to_tokens=None):
         """Shard the R3 routing ids to this rank's forward token order (RouterReplay).
 
         ``routed_experts`` is ``(B, vllm_layers, topk, S)`` (rollout top-k expert ids per
@@ -567,7 +564,7 @@ class BaseModel(nn.Module):
             # (B, layers, topk, S) seq-last -> (B*S, layers, topk) token-major, one row per token
             per_token = routing.permute(0, 3, 1, 2).reshape(b * s, n_layers, topk).long()
             if self.packing_samples:
-                per_token = per_token.index_select(0, indices)  # drop pad tokens for the packed order
+                # Already in packed token order (the collate packed routing too).
                 if pad_to_tokens is not None:
                     # Match the EP-equalized pack. Expert 0, not the -1 sentinel: Gate
                     # gathers routing weights before padding_mask drops these rows.
@@ -588,10 +585,11 @@ class BaseModel(nn.Module):
         mm_inputs: dict,
         output_hidden_states: bool = False,
         routed_experts: Optional[torch.Tensor] = None,
+        seq_lens: Optional[list] = None,
     ):
         """Input prep (packing / VLM token-type ids / CP sharding) + model call.
 
-        Returns ``(output, rolled_sequences, cp_forward, indices, batch, seqlen)``:
+        Returns ``(output, rolled_sequences, cp_forward, batch, seqlen)``:
         ``output`` is the normalized model output (``_AttrDict`` with ``logits`` and,
         for custom MoE, ``aux_loss``); the rest is the state ``_restore_full_sequence``
         needs to map a per-token tensor back onto the dense ``[B, seqlen]`` axis.
@@ -602,24 +600,32 @@ class BaseModel(nn.Module):
         """
         batch, seqlen = sequences.size()
         attn_kwargs: dict = {}
-        indices = None
         pad_to_tokens = None  # set under EP-equalized packing; also pads the routing rows
         cp_forward = False
         cp_ctx_factory = nullcontext
         cp_batch = None  # built in the packed or padded branch below; None => no CP sharding
         self._cp_sharder = None  # set below under CP; read by _restore_full_sequence / _build_routing_targets
-        if self.packing_samples and self.cp_size == 1:
-            # cp1 real-token packing. CP is incompatible with packed sequences: cp>1
-            # falls through to the padded branch, where the model-owned sharder
-            # flattens the padded [B,S] batch to THD itself (from seq_lens).
+        if seq_lens is not None:
+            # Already packed by the collate into one flat [1, total] row. Targets
+            # roll inside each sequence so none crosses a pack boundary.
+            rolled_sequences = torch.cat([torch.roll(s, -1) for s in sequences[0].split(seq_lens)]).unsqueeze(0)
+            trailing_pad = 0
             if self._ep_pad_group is not None:
-                # Packed RL responses have rank-local token counts; grow them all to the
-                # EP-group max so HybridEP's routing-map all-gather agrees on the shape.
-                local_tokens = attention_mask.count_nonzero()
+                # Rank-local token counts differ; grow them all to the EP-group max
+                # so HybridEP's routing-map all-gather agrees on the shape.
+                local_tokens = torch.tensor(sum(seq_lens), device=sequences.device)
                 dist.all_reduce(local_tokens, op=dist.ReduceOp.MAX, group=self._ep_pad_group)
                 pad_to_tokens = int(local_tokens)
-            sequences, position_ids, rolled_sequences, indices, attn_kwargs = pack_padded_batch(
-                sequences, attention_mask, style=self._packing_style, pad_to_tokens=pad_to_tokens
+                trailing_pad = pad_to_tokens - sum(seq_lens)
+                if trailing_pad:
+                    # Ids are arbitrary (masked, then dropped); positions continue the
+                    # last sequence so real tokens never attend to them.
+                    sequences = F.pad(sequences, (0, trailing_pad))
+                    rolled_sequences = F.pad(rolled_sequences, (0, trailing_pad))
+                    tail = torch.arange(seq_lens[-1], seq_lens[-1] + trailing_pad, device=position_ids.device)
+                    position_ids = torch.cat((position_ids, tail.to(position_ids.dtype).unsqueeze(0)), dim=1)
+            attn_kwargs = packed_attn_kwargs(
+                seq_lens, style=self._packing_style, device=sequences.device, trailing_pad=trailing_pad
             )
             forward_attention_mask = None
         else:
@@ -775,7 +781,7 @@ class BaseModel(nn.Module):
         if routed_experts is not None:
             from nemo_automodel.components.moe.router_replay import RouterReplay
 
-            targets = self._build_routing_targets(routed_experts, indices, cp_forward, pad_to_tokens)
+            targets = self._build_routing_targets(routed_experts, cp_forward, pad_to_tokens)
             replay_ctx = RouterReplay.replay(targets)
             # Replay must stay active through the activation-checkpoint recompute in
             # backward, else the recompute reverts to the live router and disagrees with
@@ -805,4 +811,4 @@ class BaseModel(nn.Module):
         # raw logits Tensor; HF returns a ModelOutput with `.logits`. Normalize.
         output = _normalize_output(output)
         output = attach_nemo_moe_aux_loss(output, self.model)
-        return output, rolled_sequences, cp_forward, indices, batch, seqlen
+        return output, rolled_sequences, cp_forward, batch, seqlen

--- a/molt/models/critic.py
+++ b/molt/models/critic.py
@@ -145,6 +145,7 @@ class Critic(BaseModel):
         attention_mask: Optional[torch.Tensor] = None,
         position_ids: Optional[torch.Tensor] = None,
         cp_context_stack=None,
+        seq_lens: Optional[list] = None,
         **mm_inputs,
     ) -> _AttrDict:
         """Return per-token values.
@@ -153,17 +154,15 @@ class Critic(BaseModel):
         - ``action_values``: ``[B, num_actions]`` masked to the generated span,
                              only when ``action_mask`` is given.
         """
-        output, _rolled, cp_forward, indices, batch, seqlen = self._forward_backbone(
-            sequences, attention_mask, position_ids, cp_context_stack, mm_inputs
+        output, _rolled, cp_forward, batch, seqlen = self._forward_backbone(
+            sequences, attention_mask, position_ids, cp_context_stack, mm_inputs, seq_lens=seq_lens
         )
         # Head is one-wide, so the model's "logits" are per-token values [B, S, 1].
         values = unshard_dtensor(output["logits"]).squeeze(-1).float()
-        values = self._restore_full_sequence(
-            values, cp_forward=cp_forward, batch=batch, seqlen=seqlen, indices=indices
-        )
+        values = self._restore_full_sequence(values, cp_forward=cp_forward, batch=batch, seqlen=seqlen)
         # logits[t] scores state s_t / predicts t+1; drop the final column to align
         # with action_log_probs (both live on the [:, :-1] next-token axis).
-        values = values[:, :-1]
+        values = values if seq_lens is not None else values[:, :-1]
         out = _AttrDict(values=values)
         if action_mask is not None:
             out["action_values"] = values[:, -action_mask.shape[1] :] * action_mask.float()

--- a/molt/trainer/algorithm/experience.py
+++ b/molt/trainer/algorithm/experience.py
@@ -19,6 +19,8 @@ from typing import Any, List, Union
 
 import ray
 import torch
+import torch.nn.functional as F
+from nemo_automodel.components.datasets.utils import pack_features_for_thd, packed_sequence_thd_collater
 
 from molt.utils.logging_utils import init_logger
 from molt.utils.seqlen_balancing import get_seqlen_balanced_partitions
@@ -264,6 +266,38 @@ def make_experience_batch(items: List[Experience]) -> Experience:
             kwargs[f.name] = list(itertools.chain.from_iterable(getattr(item, f.name) for item in items))
 
     return Experience(**kwargs)
+
+
+def make_packed_experience_batch(items: List[Experience]) -> dict:
+    """Pack unpadded single-sample Experiences into one flat THD microbatch.
+
+    The buffer already stores unpadded samples, so packing here replaces the
+    padded path's pad -> unpad -> pack -> re-pad round trip through the forward.
+    Token packing delegates to AutoModel's collater, keeping the packed schema
+    identical to the one its THD/CP pipeline consumes. Action-side fields are
+    [T-1]; one trailing masked slot puts them on the same [T] axis as the tokens.
+    """
+    seq_lens = [item.sequences.numel() for item in items]
+    features = [
+        {"input_ids": item.sequences.tolist(), "labels": torch.roll(item.sequences, -1, -1).tolist()} for item in items
+    ]
+    batch = packed_sequence_thd_collater([pack_features_for_thd(features)])
+
+    for f in fields(Experience):
+        value = getattr(items[0], f.name)
+        if f.name in ("sequences", "attention_mask") or not isinstance(value, torch.Tensor):
+            continue
+        if not Experience.is_step_tensor_field(f.name):
+            continue
+        if value.dim() != 1:
+            # routed_experts is [layers, topk, T]; R3 replay keeps the padded path.
+            raise ValueError(f"{f.name} is {value.dim()}-D; packing covers 1-D per-token fields only")
+        batch[f.name] = torch.cat([F.pad(getattr(item, f.name), (0, 1)) for item in items]).unsqueeze(0)
+
+    batch["cu_seqlens"] = torch.tensor([0, *itertools.accumulate(seq_lens)], dtype=torch.int32)
+    batch["max_seqlen"] = max(seq_lens)
+    batch["packed_seq_lens"] = seq_lens
+    return batch
 
 
 def remove_padding_in_sequences(items: List[Experience]) -> List[Experience]:

--- a/molt/trainer/algorithm/experience.py
+++ b/molt/trainer/algorithm/experience.py
@@ -85,6 +85,11 @@ class Experience:
     sequences: torch.Tensor = tensor_field("step", default=None)  # (B, T) token ids [prompt + response]
     attention_mask: torch.LongTensor = tensor_field("step", default=None)  # (B, T)
     action_mask: torch.BoolTensor = tensor_field("step", default=None)  # (B, T-1) generated-token steps
+    # Packed batches only: (1, T) positions restarting per sequence, and the
+    # sequence lengths that split flat model outputs back per sample. Both None
+    # for padded batches, where the forward derives positions from the mask.
+    position_ids: torch.Tensor = tensor_field("step", default=None)
+    packed_seq_lens: list[int] = None
 
     # Policy: log probs under current, reference, and rollout policies
     action_log_probs: torch.Tensor = tensor_field("step", default=None)  # (B, T-1) log pi_theta(a|s)
@@ -223,8 +228,15 @@ def split_experience_batch(experience: Experience) -> List[Experience]:
     return items
 
 
-def make_experience_batch(items: List[Experience]) -> Experience:
-    """Combine individual single-sample Experiences into a batched Experience."""
+def make_experience_batch(items: List[Experience], packed: bool = False) -> Experience:
+    """Combine individual single-sample Experiences into a batched Experience.
+
+    ``packed`` concatenates the per-token fields into one flat ``[1, total]`` THD
+    row instead of right-padding them to ``[B, T]``, so the model consumes the
+    pack directly. Action-side fields are ``[T-1]`` and gain one trailing slot --
+    no target there, and ``action_mask`` is zero -- keeping every per-token
+    tensor elementwise-aligned with the tokens.
+    """
     if not items:
         raise ValueError("Empty items list")
 
@@ -240,7 +252,11 @@ def make_experience_batch(items: List[Experience]) -> Experience:
             kwargs[f.name] = None
         elif isinstance(first, torch.Tensor):
             tensors = [getattr(item, f.name) for item in items]
-            if Experience.is_step_tensor_field(f.name):
+            if Experience.is_step_tensor_field(f.name) and packed:
+                if f.name not in ("sequences", "attention_mask", "routed_experts"):
+                    tensors = [F.pad(t, (0, 1)) for t in tensors]  # [T-1] -> [T]
+                kwargs[f.name] = torch.cat(tensors, dim=-1).unsqueeze(0)
+            elif Experience.is_step_tensor_field(f.name):
                 # routed_experts pads with the R3 -1 sentinel (keep live routing); 0 is a
                 # valid expert id and would force pad tokens to expert 0. Others pad with 0.
                 pad_value = -1 if f.name == "routed_experts" else 0
@@ -265,39 +281,24 @@ def make_experience_batch(items: List[Experience]) -> Experience:
         elif isinstance(first, list):
             kwargs[f.name] = list(itertools.chain.from_iterable(getattr(item, f.name) for item in items))
 
+    if packed:
+        # AutoModel's collater owns the token schema (flat ids + per-sequence
+        # position resets), so the pack matches what its THD pipeline consumes.
+        thd = packed_sequence_thd_collater(
+            [
+                pack_features_for_thd(
+                    [
+                        {"input_ids": i.sequences.tolist(), "labels": torch.roll(i.sequences, -1, -1).tolist()}
+                        for i in items
+                    ]
+                )
+            ]
+        )
+        kwargs["sequences"] = thd["input_ids"]
+        kwargs["position_ids"] = thd["position_ids"]
+        kwargs["packed_seq_lens"] = [i.sequences.numel() for i in items]
+
     return Experience(**kwargs)
-
-
-def make_packed_experience_batch(items: List[Experience]) -> dict:
-    """Pack unpadded single-sample Experiences into one flat THD microbatch.
-
-    The buffer already stores unpadded samples, so packing here replaces the
-    padded path's pad -> unpad -> pack -> re-pad round trip through the forward.
-    Token packing delegates to AutoModel's collater, keeping the packed schema
-    identical to the one its THD/CP pipeline consumes. Action-side fields are
-    [T-1]; one trailing masked slot puts them on the same [T] axis as the tokens.
-    """
-    seq_lens = [item.sequences.numel() for item in items]
-    features = [
-        {"input_ids": item.sequences.tolist(), "labels": torch.roll(item.sequences, -1, -1).tolist()} for item in items
-    ]
-    batch = packed_sequence_thd_collater([pack_features_for_thd(features)])
-
-    for f in fields(Experience):
-        value = getattr(items[0], f.name)
-        if f.name in ("sequences", "attention_mask") or not isinstance(value, torch.Tensor):
-            continue
-        if not Experience.is_step_tensor_field(f.name):
-            continue
-        if value.dim() != 1:
-            # routed_experts is [layers, topk, T]; R3 replay keeps the padded path.
-            raise ValueError(f"{f.name} is {value.dim()}-D; packing covers 1-D per-token fields only")
-        batch[f.name] = torch.cat([F.pad(getattr(item, f.name), (0, 1)) for item in items]).unsqueeze(0)
-
-    batch["cu_seqlens"] = torch.tensor([0, *itertools.accumulate(seq_lens)], dtype=torch.int32)
-    batch["max_seqlen"] = max(seq_lens)
-    batch["packed_seq_lens"] = seq_lens
-    return batch
 
 
 def remove_padding_in_sequences(items: List[Experience]) -> List[Experience]:

--- a/molt/trainer/algorithm/replay_buffer.py
+++ b/molt/trainer/algorithm/replay_buffer.py
@@ -48,6 +48,7 @@ class NaiveReplayBuffer:
         limit: int = 0,
         cpu_offload: bool = True,
         dynamic_batch: bool = False,
+        packing: bool = False,
     ) -> None:
         super().__init__()
         self.sample_batch_size = sample_batch_size
@@ -56,6 +57,7 @@ class NaiveReplayBuffer:
         self.cpu_offload = cpu_offload
         self.items: List[Experience] = []
         self.dynamic_batch = dynamic_batch
+        self.packing = packing
         self.dynamic_indices: List[List[int]] = []
         self.dynamic_optimizer_step: List[int] = []
 
@@ -88,7 +90,7 @@ class NaiveReplayBuffer:
     def collate_fn(self, batch) -> Experience:
         if self.dynamic_batch:
             batch = batch[0]
-        return make_experience_batch(batch)
+        return make_experience_batch(batch, packed=self.packing)
 
     def setup_dynamic_batch(self, strategy):
         args = strategy.args

--- a/molt/trainer/fsdp/packing.py
+++ b/molt/trainer/fsdp/packing.py
@@ -24,11 +24,11 @@ kwargs depend on the selected model path:
   (``qkv_format=thd`` / ``cu_seqlens`` / ``max_seqlen``).
 """
 
+import itertools
 from typing import Any
 
 import torch
 import torch.distributed as dist
-import torch.nn.functional as F
 from torch.distributed.tensor import DTensor
 
 
@@ -67,94 +67,44 @@ def is_automodel_custom_model(model: Any) -> bool:
     return False
 
 
-def pack_padded_batch(
-    sequences: torch.Tensor,
-    attention_mask: torch.Tensor,
-    *,
-    style: str = "hf",
-    pad_to_tokens: int | None = None,
-):
-    """Convert a padded `(B, S)` batch to packed `(1, total_real_tokens)` format.
+def packed_attn_kwargs(seq_lens: list[int], *, style: str, device, trailing_pad: int = 0) -> dict:
+    """Varlen attention kwargs for an already-packed `(1, total_tokens)` batch.
 
-    Returns:
-        packed_input_ids: `(1, total_real_tokens)` with pad tokens removed
-        position_ids:     `(1, total_real_tokens)` with resets at sequence boundaries
-        rolled_input_ids: `(1, total_real_tokens)` from `torch.roll(input_ids, -1)` then unpadded
-        indices:          flat indices into `(B*S,)` of real tokens (for `unpack_to_padded`)
-        attn_kwargs:      HF FlashAttention kwargs or AutoModel THD kwargs
+    The collate builds the pack (`make_experience_batch(packed=True)`); this only
+    describes its sequence boundaries to the attention kernel.
 
-    ``pad_to_tokens`` extends the last packed sequence with synthetic tokens so EP ranks
-    agree on the token count. They are causal-suffixed (real outputs unchanged), flagged
-    in ``padding_mask`` so experts skip them, and dropped by :func:`unpack_to_padded`.
+    ``trailing_pad`` covers the EP-equalized suffix, whose length is a collective
+    and so is known only at forward time: it extends the last sequence, is flagged
+    in ``padding_mask`` so experts skip it, and is causal-suffixed, leaving real
+    tokens' outputs unchanged.
     """
     if style not in {"hf", "automodel"}:
         raise ValueError(f"Unsupported packing style: {style}")
 
-    batch, seqlen = sequences.shape
-    mask = attention_mask.bool()
-    indices = mask.reshape(-1).nonzero(as_tuple=False).flatten()
-    seq_lens = mask.sum(dim=-1, dtype=torch.int32)
-    # torch.cumsum on int32 promotes to int64; varlen attention kernels require
-    # int32 sequence lengths. Cast back explicitly.
-    cu_seq_lens = torch.cat(
-        [torch.zeros(1, dtype=torch.int32, device=sequences.device), torch.cumsum(seq_lens, dim=0).to(torch.int32)]
-    )
-    max_length = seq_lens.max().item() if seq_lens.numel() > 0 else 0
-
-    packed_ids = sequences.reshape(batch * seqlen).index_select(0, indices).unsqueeze(0)
-    rolled = torch.roll(sequences, shifts=-1, dims=1)
-    rolled_packed = rolled.reshape(batch * seqlen).index_select(0, indices).unsqueeze(0)
-
-    # position_ids reset at seq boundaries (`[0,1,2, 0,1, 0,1,2,3]`).
-    position_ids_full = torch.clip(torch.cumsum(attention_mask, dim=-1) - 1, min=0)
-    position_ids = position_ids_full.reshape(batch * seqlen).index_select(0, indices).unsqueeze(0)
-
-    real_tokens = int(indices.numel())
-    trailing_pad = 0 if pad_to_tokens is None else pad_to_tokens - real_tokens
+    boundaries = list(itertools.accumulate(seq_lens, initial=0))
+    max_length = max(seq_lens)
     if trailing_pad:
-        # Token ids are arbitrary (these rows are masked and then dropped); the
-        # positions continue the last sequence so real tokens never attend to them.
-        last_len = int(seq_lens[-1])
-        packed_ids = F.pad(packed_ids, (0, trailing_pad))
-        rolled_packed = F.pad(rolled_packed, (0, trailing_pad))
-        pad_positions = torch.arange(last_len, last_len + trailing_pad, device=position_ids.device)
-        position_ids = torch.cat((position_ids, pad_positions.to(position_ids.dtype).unsqueeze(0)), dim=1)
-        cu_seq_lens = cu_seq_lens.clone()
-        cu_seq_lens[-1] += trailing_pad
-        max_length = max(max_length, last_len + trailing_pad)
+        boundaries[-1] += trailing_pad
+        max_length = max(max_length, seq_lens[-1] + trailing_pad)
+    cu_seq_lens = torch.tensor(boundaries, dtype=torch.int32, device=device)  # varlen kernels need int32
 
-    if style == "automodel":
-        attn_kwargs = {
-            "qkv_format": "thd",
-            "cu_seqlens": cu_seq_lens,
-            "cu_seqlens_padded": cu_seq_lens,
-            "max_seqlen": int(max_length),
-        }
-        if trailing_pad:
-            is_pad = torch.arange(real_tokens + trailing_pad, device=sequences.device) >= real_tokens
-            attn_kwargs["padding_mask"] = is_pad.unsqueeze(0)
-    else:
-        attn_kwargs = {
+    if style == "hf":
+        return {
             "cu_seq_lens_q": cu_seq_lens,
             "cu_seq_lens_k": cu_seq_lens,
-            "max_length_q": int(max_length),
-            "max_length_k": int(max_length),
+            "max_length_q": max_length,
+            "max_length_k": max_length,
         }
-    return packed_ids, position_ids, rolled_packed, indices, attn_kwargs
-
-
-def unpack_to_padded(packed: torch.Tensor, indices: torch.Tensor, batch: int, seqlen: int) -> torch.Tensor:
-    """Inverse of `pack_padded_batch` (logits / log-probs side).
-
-    Takes a `(1, total_real_tokens)` tensor and returns a `(B, S)` padded tensor
-    using the `indices` from the original pack.
-    """
-    packed_values = packed.squeeze(0) if packed.dim() > 1 and packed.shape[0] == 1 else packed
-    # An EP-equalized pack carries a synthetic suffix with no [B, S] destination.
-    packed_values = packed_values[: indices.numel()]
-    output = packed_values.new_zeros((batch * seqlen, *packed_values.shape[1:]))
-    output.index_copy_(0, indices, packed_values)
-    return output.view(batch, seqlen, *packed_values.shape[1:])
+    kwargs = {
+        "qkv_format": "thd",
+        "cu_seqlens": cu_seq_lens,
+        "cu_seqlens_padded": cu_seq_lens,
+        "max_seqlen": max_length,
+    }
+    if trailing_pad:
+        real_tokens = sum(seq_lens)
+        kwargs["padding_mask"] = (torch.arange(real_tokens + trailing_pad, device=device) >= real_tokens).unsqueeze(0)
+    return kwargs
 
 
 def _distributed_log_softmax(local_logits: torch.Tensor, group: dist.ProcessGroup) -> torch.Tensor:

--- a/molt/trainer/workers/actor_group.py
+++ b/molt/trainer/workers/actor_group.py
@@ -166,6 +166,8 @@ class ReferenceModelActor(BaseModelActor):
                 experience.sequences.to(device),
                 experience.action_mask.to(device),
                 experience.attention_mask.to(device),
+                position_ids=None if experience.position_ids is None else experience.position_ids.to(device),
+                seq_lens=experience.packed_seq_lens,
                 **mm_inputs,
             )
         return output["action_log_probs"].to("cpu")

--- a/molt/trainer/workers/critic_actor.py
+++ b/molt/trainer/workers/critic_actor.py
@@ -84,6 +84,7 @@ class CriticTrainer:
             0,
             buffer_cpu_offload,
             dynamic_batch=self.args.train.dynamic_batch_enable,
+            packing=self.args.fsdp.packing_samples,
         )
         # AutoModel's MFU calculator over the value model (same backbone as the
         # actor -> ~same FLOP/token); None if AutoModel/arch unsupported, then we
@@ -205,6 +206,8 @@ class CriticTrainer:
                 experience.sequences,
                 experience.action_mask,
                 attention_mask=experience.attention_mask,
+                position_ids=experience.position_ids,
+                seq_lens=experience.packed_seq_lens,
                 cp_context_stack=cp_context_stack,
                 **multimodal_inputs,
             )
@@ -346,6 +349,8 @@ class CriticModelActor(BaseModelActor):
                 experience.sequences.to(device),
                 experience.action_mask.to(device),
                 experience.attention_mask.to(device),
+                position_ids=None if experience.position_ids is None else experience.position_ids.to(device),
+                seq_lens=experience.packed_seq_lens,
                 **mm_inputs,
             )
         self.critic.train()  # reset model state

--- a/molt/trainer/workers/policy_actor.py
+++ b/molt/trainer/workers/policy_actor.py
@@ -119,6 +119,7 @@ class PolicyTrainer:
             buffer_limit,
             buffer_cpu_offload,
             dynamic_batch=self.args.train.dynamic_batch_enable,
+            packing=self.args.fsdp.packing_samples,
         )
 
         # Init torch group for weights sync (NCCL only — async-split topology
@@ -386,6 +387,8 @@ class PolicyTrainer:
             sequences,
             action_mask,
             attention_mask=attention_mask,
+            position_ids=experience.position_ids,
+            seq_lens=experience.packed_seq_lens,
             cp_context_stack=cp_context_stack,
             # entropy_coef=0.0 disables the entropy term in loss. Skip the
             # entropy forward path entirely in that case.
@@ -885,6 +888,8 @@ class PolicyModelActor(BaseModelActor):
                 experience.sequences.to(device),
                 experience.action_mask.to(device),
                 experience.attention_mask.to(device),
+                position_ids=None if experience.position_ids is None else experience.position_ids.to(device),
+                seq_lens=experience.packed_seq_lens,
                 # R3: replay rollout routing so old picks the same experts as training.
                 routed_experts=routed_experts.to(device) if routed_experts is not None else None,
                 **mm_inputs,

--- a/tests/unit/test_collect_rollout_rewards.py
+++ b/tests/unit/test_collect_rollout_rewards.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 """Rollout reward metrics must not weight a trajectory by how many turns it took."""
+
 import types
 
 import pytest

--- a/tests/unit/test_cp_thd_packing.py
+++ b/tests/unit/test_cp_thd_packing.py
@@ -21,7 +21,7 @@ model-owned ``ContextParallelSharder``. round_robin models (omni3/qwen3.6) pass
 and the sharder flattens ``[B,S] -> [B*S]`` itself. The gather inverts the layout back
 to ``[B,S]`` — no packing/unpacking on the CP path. Covered here without GPU/tilelang:
 
-1. ``_restore_full_sequence``: cp>1 just gathers to ``[B,S]``; cp1 packing scatters.
+1. ``_restore_full_sequence``: cp>1 gathers to ``[B,S]``; a packed batch stays flat.
 2. The molt<->AutoModel contract: the ``[B,S]`` cp_batch molt builds is a valid sharder
    input yielding the layout molt's gather inverts (GLM ``input_row_shape``, DSv4 repad).
 3. The real cross-rank gather roundtrip + cp_size sum-backward (gloo).
@@ -35,7 +35,7 @@ import pytest
 import torch
 
 from molt.models.base import BaseModel
-from molt.trainer.fsdp.packing import pack_padded_batch, unpack_to_padded
+from molt.trainer.fsdp.packing import packed_attn_kwargs
 
 
 def test_restore_cp_gathers_to_bs_and_drops_cp_pad():
@@ -51,43 +51,36 @@ def test_restore_cp_gathers_to_bs_and_drops_cp_pad():
     for packing in (True, False):  # THD DSA vs round_robin
         calls.clear()
         stub = SimpleNamespace(packing_samples=packing, _cp_sharder=SimpleNamespace(gather_token_tensor=_gather))
-        out = BaseModel._restore_full_sequence(
-            stub, torch.zeros(2, 3), cp_forward=True, batch=2, seqlen=3, indices=None
-        )
+        out = BaseModel._restore_full_sequence(stub, torch.zeros(2, 3), cp_forward=True, batch=2, seqlen=3)
         assert calls == {"seq_dim": 1, "trim": True, "fill": 0.0}
         assert torch.equal(out, restored[:, :3])  # [B,S] without the pad; no unpack under cp>1
 
 
-def test_restore_packing_cp1_scatters_to_bs():
-    # cp1 real-token packing (no CP): scatter the packed [1, total] back to [B, S].
-    B, S = 2, 3
-    indices = torch.tensor([0, 1, 3, 4, 5])
+def test_restore_leaves_a_packed_batch_flat():
+    # The collate packs, so per-token outputs already share the flat [1, total]
+    # axis with their inputs -- there is nothing to invert.
     packed = torch.tensor([[1.0, 2.0, 3.0, 4.0, 5.0]])
     stub = SimpleNamespace(packing_samples=True, _cp_sharder=None)
-    out = BaseModel._restore_full_sequence(stub, packed, cp_forward=False, batch=B, seqlen=S, indices=indices)
-    assert out.shape == (B, S)
-    assert out.reshape(-1).tolist() == [1.0, 2.0, 0.0, 3.0, 4.0, 5.0]
+    out = BaseModel._restore_full_sequence(stub, packed, cp_forward=False, batch=2, seqlen=3)
+    assert out is packed
 
 
-def test_ep_equalized_packing_masks_and_drops_synthetic_suffix():
-    sequences = torch.tensor([[10, 11, 0, 0], [20, 21, 22, 0]])
-    attention_mask = torch.tensor([[1, 1, 0, 0], [1, 1, 1, 0]])
+def test_ep_equalized_packing_extends_the_last_sequence():
+    # The EP suffix is a forward-time step (its length is a collective): it grows
+    # the last sequence and is flagged so experts skip it.
+    kwargs = packed_attn_kwargs([2, 3], style="automodel", device="cpu", trailing_pad=3)
 
-    packed, positions, _rolled, indices, kwargs = pack_padded_batch(
-        sequences, attention_mask, style="automodel", pad_to_tokens=8
-    )
-
-    assert packed.tolist() == [[10, 11, 20, 21, 22, 0, 0, 0]]
-    assert positions.tolist() == [[0, 1, 0, 1, 2, 3, 4, 5]]
     assert kwargs["cu_seqlens"].tolist() == [0, 2, 8]
     assert kwargs["cu_seqlens_padded"].tolist() == [0, 2, 8]
     assert kwargs["max_seqlen"] == 6
-    assert kwargs["padding_mask"].tolist() == [[False, False, False, False, False, True, True, True]]
+    assert kwargs["padding_mask"].tolist() == [[False] * 5 + [True] * 3]
 
-    # Model-side outputs include the synthetic suffix, but restore scatters only
-    # the five original real-token rows back into [B, S].
-    restored = unpack_to_padded(torch.arange(1, 9).view(1, 8), indices, batch=2, seqlen=4)
-    assert restored.tolist() == [[1, 2, 0, 0], [3, 4, 5, 0]]
+
+def test_packed_attn_kwargs_hf_style():
+    kwargs = packed_attn_kwargs([2, 3], style="hf", device="cpu")
+    assert kwargs["cu_seq_lens_q"].tolist() == [0, 2, 5]
+    assert kwargs["max_length_q"] == 3
+    assert "qkv_format" not in kwargs
 
 
 class _FakeMesh:  # single-process stand-in; make_* reads size() + get_group()

--- a/tests/unit/test_routing_replay.py
+++ b/tests/unit/test_routing_replay.py
@@ -154,7 +154,7 @@ def test_build_routing_targets_selects_sparse_hybrid_global_layer_ids():
                 routed[b, layer, 0, t] = 100 * b + 10 * layer + t
 
     stub = SimpleNamespace(packing_samples=False, _num_routing_gates=len(global_ids), _moe_layer_global_ids=global_ids)
-    targets = BaseModel._build_routing_targets(stub, routed, indices=None, cp_forward=False)
+    targets = BaseModel._build_routing_targets(stub, routed, cp_forward=False)
 
     assert len(targets) == len(global_ids)
     for i, gid in enumerate(global_ids):
@@ -187,7 +187,7 @@ def test_build_routing_targets_cp_delegates_to_sharder():
         _moe_layer_global_ids=list(range(L)),
         _cp_sharder=SimpleNamespace(shard_token_tensor=_shard),
     )
-    targets = BaseModel._build_routing_targets(stub, routed, indices=None, cp_forward=True)
+    targets = BaseModel._build_routing_targets(stub, routed, cp_forward=True)
 
     assert calls == {"seq_dim": 3, "fill": -1}  # -1 fill keeps CP pad tokens on live routing
     assert len(targets) == L
@@ -208,7 +208,7 @@ def test_build_routing_targets_preserves_minus_one_sentinel():
             routed[0, layer, 0, t] = 10 * layer + t
 
     stub = SimpleNamespace(packing_samples=False, _num_routing_gates=L, _moe_layer_global_ids=list(range(L)))
-    targets = BaseModel._build_routing_targets(stub, routed, indices=None, cp_forward=False)
+    targets = BaseModel._build_routing_targets(stub, routed, cp_forward=False)
 
     for layer in range(L):
         assert (targets[layer][0] == -1).all()  # prompt row stays sentinel -> live routing
@@ -221,10 +221,8 @@ def test_build_routing_targets_pads_hybridep_suffix_with_valid_masked_expert():
         routed[0, layer, 0] = torch.tensor([10 * layer, 10 * layer + 1, 10 * layer + 2])
 
     stub = SimpleNamespace(packing_samples=True, _num_routing_gates=L, _moe_layer_global_ids=list(range(L)))
-    # Only tokens 0 and 1 are real on this rank; HybridEP equalizes it to four.
-    targets = BaseModel._build_routing_targets(
-        stub, routed, indices=torch.tensor([0, 1]), cp_forward=False, pad_to_tokens=4
-    )
+    # Routing arrives in packed token order; HybridEP equalizes the count to four.
+    targets = BaseModel._build_routing_targets(stub, routed[:, :, :, :2], cp_forward=False, pad_to_tokens=4)
 
     for layer in range(L):
         assert targets[layer].shape == (4, K)

--- a/tests/unit/test_thd_packing.py
+++ b/tests/unit/test_thd_packing.py
@@ -1,0 +1,78 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Collate-time THD packing parity with the forward-time packer it replaces."""
+
+import pytest
+import torch
+
+from molt.trainer.algorithm.experience import Experience, make_experience_batch, make_packed_experience_batch
+from molt.trainer.fsdp.packing import pack_padded_batch
+
+
+def _loose_items():
+    """Two per-sample records, as NaiveReplayBuffer stores them (padding removed)."""
+    return [
+        Experience(
+            sequences=torch.tensor([10, 11, 12]),
+            attention_mask=torch.tensor([1, 1, 1]),
+            action_mask=torch.tensor([True, True]),
+            advantages=torch.tensor([0.5, 0.5]),
+            action_log_probs=torch.tensor([-0.1, -0.2]),
+        ),
+        Experience(
+            sequences=torch.tensor([20, 21]),
+            attention_mask=torch.tensor([1, 1]),
+            action_mask=torch.tensor([True]),
+            advantages=torch.tensor([0.9]),
+            action_log_probs=torch.tensor([-0.3]),
+        ),
+    ]
+
+
+def test_packs_tokens_like_the_forward_packer():
+    packed = make_packed_experience_batch(_loose_items())
+
+    # The path it replaces: rebuild the padded batch, then pack inside the forward.
+    padded = make_experience_batch(_loose_items())
+    ref_ids, ref_pos, ref_rolled, _, ref_kwargs = pack_padded_batch(
+        padded.sequences, padded.attention_mask, style="automodel"
+    )
+
+    assert torch.equal(packed["input_ids"], ref_ids)
+    assert torch.equal(packed["position_ids"], ref_pos)
+    assert torch.equal(packed["cu_seqlens"], ref_kwargs["cu_seqlens"])
+    assert packed["max_seqlen"] == ref_kwargs["max_seqlen"]
+    assert packed["packed_seq_lens"] == [3, 2]
+    # Per-sample and padded-row rolls agree wherever a target exists; each
+    # sample's final position has none and is masked out.
+    scored = packed["action_mask"][0].bool()
+    assert scored.tolist() == [True, True, False, True, False]
+    assert torch.equal(packed["labels"][0][scored], ref_rolled[0][scored])
+
+
+def test_side_inputs_ride_the_flat_token_axis():
+    packed = make_packed_experience_batch(_loose_items())
+
+    assert packed["advantages"].shape == packed["input_ids"].shape
+    assert packed["advantages"][0].tolist() == pytest.approx([0.5, 0.5, 0.0, 0.9, 0.0])
+    assert packed["action_log_probs"][0].tolist() == pytest.approx([-0.1, -0.2, 0.0, -0.3, 0.0])
+
+
+def test_token_mean_loss_is_layout_invariant():
+    """A masked sum over the flat axis equals the padded one — why packing is free."""
+    packed = make_packed_experience_batch(_loose_items())
+    padded = make_experience_batch(_loose_items())
+
+    flat_sum = (packed["advantages"] * packed["action_mask"]).sum()
+    padded_sum = (padded.advantages * padded.action_mask).sum()
+
+    assert torch.allclose(flat_sum, padded_sum)
+
+
+def test_multi_dim_per_token_field_is_rejected():
+    items = _loose_items()
+    items[0].values = torch.zeros(2, 3, 2)  # R3-style [layers, topk, T]
+    items[1].values = torch.zeros(2, 3, 1)
+    with pytest.raises(ValueError, match="1-D per-token fields only"):
+        make_packed_experience_batch(items)

--- a/tests/unit/test_thd_packing.py
+++ b/tests/unit/test_thd_packing.py
@@ -7,7 +7,6 @@ import pytest
 import torch
 
 from molt.trainer.algorithm.experience import Experience, make_experience_batch
-from molt.trainer.fsdp.packing import pack_padded_batch
 
 
 def _loose_items():
@@ -30,15 +29,12 @@ def _loose_items():
     ]
 
 
-def test_packs_tokens_like_the_forward_packer():
+def test_packs_tokens_into_one_flat_row():
     packed = make_experience_batch(_loose_items(), packed=True)
 
-    # The path it replaces: rebuild the padded batch, then pack inside the forward.
-    padded = make_experience_batch(_loose_items())
-    ref_ids, ref_pos, _, _, _ = pack_padded_batch(padded.sequences, padded.attention_mask, style="automodel")
-
-    assert torch.equal(packed.sequences, ref_ids)
-    assert torch.equal(packed.position_ids, ref_pos)
+    assert packed.sequences.tolist() == [[10, 11, 12, 20, 21]]
+    # Positions restart per sequence -- what makes varlen attention split the pack.
+    assert packed.position_ids.tolist() == [[0, 1, 2, 0, 1]]
     assert packed.packed_seq_lens == [3, 2]
 
 

--- a/tests/unit/test_thd_packing.py
+++ b/tests/unit/test_thd_packing.py
@@ -6,7 +6,7 @@
 import pytest
 import torch
 
-from molt.trainer.algorithm.experience import Experience, make_experience_batch, make_packed_experience_batch
+from molt.trainer.algorithm.experience import Experience, make_experience_batch
 from molt.trainer.fsdp.packing import pack_padded_batch
 
 
@@ -31,48 +31,46 @@ def _loose_items():
 
 
 def test_packs_tokens_like_the_forward_packer():
-    packed = make_packed_experience_batch(_loose_items())
+    packed = make_experience_batch(_loose_items(), packed=True)
 
     # The path it replaces: rebuild the padded batch, then pack inside the forward.
     padded = make_experience_batch(_loose_items())
-    ref_ids, ref_pos, ref_rolled, _, ref_kwargs = pack_padded_batch(
-        padded.sequences, padded.attention_mask, style="automodel"
-    )
+    ref_ids, ref_pos, _, _, _ = pack_padded_batch(padded.sequences, padded.attention_mask, style="automodel")
 
-    assert torch.equal(packed["input_ids"], ref_ids)
-    assert torch.equal(packed["position_ids"], ref_pos)
-    assert torch.equal(packed["cu_seqlens"], ref_kwargs["cu_seqlens"])
-    assert packed["max_seqlen"] == ref_kwargs["max_seqlen"]
-    assert packed["packed_seq_lens"] == [3, 2]
-    # Per-sample and padded-row rolls agree wherever a target exists; each
-    # sample's final position has none and is masked out.
-    scored = packed["action_mask"][0].bool()
-    assert scored.tolist() == [True, True, False, True, False]
-    assert torch.equal(packed["labels"][0][scored], ref_rolled[0][scored])
+    assert torch.equal(packed.sequences, ref_ids)
+    assert torch.equal(packed.position_ids, ref_pos)
+    assert packed.packed_seq_lens == [3, 2]
 
 
 def test_side_inputs_ride_the_flat_token_axis():
-    packed = make_packed_experience_batch(_loose_items())
+    packed = make_experience_batch(_loose_items(), packed=True)
 
-    assert packed["advantages"].shape == packed["input_ids"].shape
-    assert packed["advantages"][0].tolist() == pytest.approx([0.5, 0.5, 0.0, 0.9, 0.0])
-    assert packed["action_log_probs"][0].tolist() == pytest.approx([-0.1, -0.2, 0.0, -0.3, 0.0])
+    # Action-side fields are [T-1] and gain one trailing masked slot per sample,
+    # so they stay elementwise-aligned with the tokens.
+    assert packed.advantages.shape == packed.sequences.shape
+    assert packed.advantages[0].tolist() == pytest.approx([0.5, 0.5, 0.0, 0.9, 0.0])
+    assert packed.action_log_probs[0].tolist() == pytest.approx([-0.1, -0.2, 0.0, -0.3, 0.0])
+    assert packed.action_mask[0].tolist() == [True, True, False, True, False]
 
 
 def test_token_mean_loss_is_layout_invariant():
     """A masked sum over the flat axis equals the padded one — why packing is free."""
-    packed = make_packed_experience_batch(_loose_items())
+    packed = make_experience_batch(_loose_items(), packed=True)
     padded = make_experience_batch(_loose_items())
 
-    flat_sum = (packed["advantages"] * packed["action_mask"]).sum()
+    flat_sum = (packed.advantages * packed.action_mask).sum()
     padded_sum = (padded.advantages * padded.action_mask).sum()
 
     assert torch.allclose(flat_sum, padded_sum)
 
 
-def test_multi_dim_per_token_field_is_rejected():
+def test_routed_experts_pack_on_the_sequence_axis():
+    """R3 routing ids are [layers, topk, T] with the sequence last, so they concatenate."""
     items = _loose_items()
-    items[0].values = torch.zeros(2, 3, 2)  # R3-style [layers, topk, T]
-    items[1].values = torch.zeros(2, 3, 1)
-    with pytest.raises(ValueError, match="1-D per-token fields only"):
-        make_packed_experience_batch(items)
+    items[0].routed_experts = torch.zeros(2, 1, 3, dtype=torch.long)
+    items[1].routed_experts = torch.ones(2, 1, 2, dtype=torch.long)
+
+    packed = make_experience_batch(items, packed=True)
+
+    assert packed.routed_experts.shape == (1, 2, 1, 5)
+    assert packed.routed_experts[0, 0, 0].tolist() == [0, 0, 0, 1, 1]


### PR DESCRIPTION
## What

Packs each microbatch **once, at collate time**, instead of padding it and then
un-padding it again inside the model forward.

The replay buffer already stores unpadded per-sample records. Today
`make_experience_batch` re-pads them to `[B, T]`, `pack_padded_batch` strips that
padding back out inside `_forward_backbone`, and `unpack_to_padded` re-pads the
outputs before the loss. `make_experience_batch(packed=True)` produces the flat
`[1, total_tokens]` THD batch directly, and the forward consumes it.

The token schema comes from AutoModel's `pack_features_for_thd` +
`packed_sequence_thd_collater` rather than being re-derived here, so the pack is
identical to the one AutoModel's own THD/CP pipeline builds. That matters more
than it looks: the load-bearing field is `position_ids` restarting per sequence,
which is what the flash-attention backend uses to infer sequence boundaries.

## Net effect

`12 files changed, 124 insertions(+), 164 deletions(-)`

- `pack_padded_batch` (74 lines) → `packed_attn_kwargs` (~35): it no longer
  removes padding, builds positions, or rolls targets — the collate does.
- `unpack_to_padded` deleted outright. A packed batch needs no inverse: per-token
  outputs keep the flat axis their inputs already share, so
  `_restore_full_sequence` handles only the cp>1 gather.
- The packer's index map disappears with it — routing targets are already in
  packed order, and `_forward_backbone` returns a 5-tuple instead of threading it out.
- The per-sample shift disappears: each sequence gets a trailing masked slot at
  collate time, so `log_probs` / `entropy` / `values` stay elementwise-aligned
  with `action_mask`, and the `[:, :-1]` slice now applies to padded batches only.

What did **not** disappear is the EP token-count equalization: its length is a
collective, so it stays a forward-time step that extends an existing pack.

## Validation

- **GPU, one node, tiny Qwen3** (`logs/actor_parity.py`): the Actor's
  `action_log_probs` for padded vs packed input agree to **0.0** on every scored
  position. A control (`logs/parity_control.py`) shows the same comparison fails
  by 1.13 when `position_ids` are dropped, i.e. the test can fail.
- 218 CPU unit tests pass; `compileall` clean.
- Not yet exercised: a full RL training run, CP>1 (unchanged path, but untested
  here), and VLM (`packing_samples` is already force-disabled for VLM).

## Dependency

Blocked on [NVIDIA-NeMo/Automodel#3514](https://github.com/NVIDIA-NeMo/Automodel/pull/3514), which adds
`pack_features_for_thd`. CI stays red until that merges and `requirements.txt`
bumps the `nemo-automodel` pin.
