### PR TITLE
Env close teardown

### DIFF
--- a/examples/python/agents/alfworld.py
+++ b/examples/python/agents/alfworld.py
@@ -1,0 +1,302 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Multi-turn AlfWorld (TextWorld) env — natural-language household tasks.
+
+Each turn the model emits one command ("go to drawer 1"); the env steps the
+TextWorld game and feeds the new observation back as a ChatML user turn, up to
+MAX_AGENT_TURNS. Reward is a 0/1 terminal signal read from infos["won"]. Same
+multi-turn Env/StepEnvRunner shape as geo3k.py, but the "tool" is the game
+engine itself — there is no <tool_call> to parse, the action text is the command.
+
+Prereq (one-time): `pip install alfworld textworld[gym]` and `alfworld-download`;
+ALFWORLD_DATA must point at the downloaded json_* tree. The dataset row's `label`
+(written by prepare_alfworld.py rl, surfaced via --data.label_key) carries the
+absolute path to a single .tw-pddl game file, which this env binds one per episode.
+
+Process isolation. Each game runs in its own child Python process (one AlfWorldEnv
+-> one subprocess), which is the only reliable isolation for TextWorld's grammar
+parser (tatsu): it keeps process-wide shared parse state, so running several games
+in one process — even serialized on a single thread — corrupts it
+(pop-from-empty-list, FailedToken, "...Node object is not iterable"). The parent
+speaks a tiny JSON-lines protocol over the child's stdin/stdout and never imports
+textworld itself, so the tatsu state is fenced off by the OS. Memory cost of the
+isolation: each in-flight episode owns a full textworld process, so peak subprocess
+count ~= num_runners * n_samples_per_prompt; bound it via the usual rollout knobs
+if a node is memory-tight.
+
+Environment variables:
+  MAX_AGENT_TURNS       (default 30)  — per-episode command cap (agent-enforced).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import collections
+import contextlib
+import json
+import logging
+import os
+import sys
+
+import torch
+
+from molt.agents import Env, Result, StepEnvRunner
+
+logger = logging.getLogger(__name__)
+
+_MAX_TURNS = int(os.environ.get("MAX_AGENT_TURNS", "30"))
+# textworld also caps episode length; set far above our turn cap so it never
+# pre-empts the agent's own truncation.
+_MAX_EPISODE_STEPS = 1000
+_MAX_ADMISSIBLE = 30  # valid-action hints surfaced per feedback
+# Per-request wall-clock cap (textworld steps are sub-second; generous bound for a
+# pathological first load). On timeout the worker is killed and the rollout dropped.
+_STEP_TIMEOUT = 60
+_CLOSE_TIMEOUT = 10
+_STDERR_TAIL = 200  # child stderr lines retained for error messages
+
+# The child runs this script via `python -c`. It owns one textworld env for the
+# episode and answers a JSON-lines request loop on stdin/stdout: init|step|close.
+_TW_WORKER_SRC = r'''
+import json
+import os
+import sys
+import traceback
+
+# Reserve the child's real stdout (fd 1) for the JSON protocol and route stray
+# prints (textworld/alfworld chatter) at stderr. dup fd 1 BEFORE rebinding
+# sys.stdout: rebinding drops the last reference to the old stdout object, whose
+# GC would close fd 1 — the very descriptor we now hold the protocol on.
+_proto_fd = os.dup(1)
+sys.stdout = sys.stderr
+
+
+def _send(obj):
+    data = (json.dumps(obj, ensure_ascii=False) + "\n").encode("utf-8")
+    while data:
+        data = data[os.write(_proto_fd, data):]
+
+
+env = None
+try:
+    while True:
+        line = sys.stdin.readline()
+        if not line:  # parent closed stdin -> episode over
+            break
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            msg = json.loads(line)
+            cmd = msg.get("cmd")
+            if cmd == "init":
+                import textworld
+                import textworld.gym
+                from alfworld.agents.environment.alfred_tw_env import AlfredDemangler
+
+                infos = textworld.EnvInfos(won=True, admissible_commands=True)
+                env_id = textworld.gym.register_game(
+                    msg["gamefile"], infos,
+                    max_episode_steps=int(msg.get("max_episode_steps", 1000)),
+                    wrappers=[AlfredDemangler()],
+                )
+                env = textworld.gym.make(env_id)
+                out = env.reset()  # reset emits the welcome banner: room receptacles + task
+                _send({"ok": True, "obs0": out[0] if isinstance(out, tuple) else out})
+            elif cmd == "step":
+                obs, _score, _done, info = env.step(msg["action"])
+                _send({"ok": True, "obs": obs,
+                       "admissible": list(info["admissible_commands"]),
+                       "won": bool(info["won"])})
+            elif cmd == "close":
+                break
+            else:
+                _send({"ok": False, "error": "unknown cmd: " + str(cmd)})
+                break
+        except Exception:
+            _send({"ok": False, "error": "worker exception",
+                   "traceback": traceback.format_exc()})
+            break
+finally:
+    if env is not None:
+        try:
+            env.close()
+        except Exception:
+            pass
+'''
+
+
+# Closes the assistant turn vLLM left open (it strips the stop token from the
+# generated action) and opens the next user turn. Seeds <think> so each turn
+# reasons before emitting the command, paired with the turn-1 seed in reset();
+# mirrors geo3k.py's _tool_observation minus the tool_response wrapper. Needs a
+# generous --rollout.max_new_tokens or the think block won't close before the cap.
+def _observation_feedback(obs_text: str, admissible: list[str]) -> str:
+    cmds = ", ".join(admissible[:_MAX_ADMISSIBLE])
+    body = f"{obs_text}\nAdmissible actions: {cmds}" if cmds else obs_text
+    return f"<|im_end|>\n<|im_start|>user\n{body}<|im_end|>\n<|im_start|>assistant\n<think>\n"
+
+
+class AlfWorldEnv(Env):
+    def __init__(self):
+        self.turn = 0
+        self.proc = None
+        self._stderr_tail = collections.deque(maxlen=_STDERR_TAIL)
+        self._stderr_task = None
+
+    async def reset(self, state):
+        self.turn = 0
+        gamefile = state.get("label")
+        if not gamefile:
+            raise ValueError(
+                "AlfWorldEnv needs the .tw-pddl path in state['label'] "
+                "— set --data.label_key to the column prepare_alfworld.py rl wrote."
+            )
+        self.proc = await asyncio.create_subprocess_exec(
+            sys.executable, "-c", _TW_WORKER_SRC,
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        # A chatty textworld can fill the stderr pipe buffer and block the child;
+        # drain it on a background task and keep a tail for error messages.
+        self._stderr_task = asyncio.create_task(self._drain_stderr())
+        reply = await self._round_trip(
+            {"cmd": "init", "gamefile": gamefile, "max_episode_steps": _MAX_EPISODE_STEPS}
+        )
+        # Surface the reset observation (welcome banner + receptacle list) in the first
+        # user turn, matching SFT: it's the only place the room's admissible "go to X"
+        # targets appear (a mid-room `look` returns "see nothing"). Seed <think> here,
+        # paired with the same seed in _observation_feedback for later turns.
+        room_obs = reply["obs0"].split("\n\nYour task is to:")[0]
+        marker = "<|im_end|>\n<|im_start|>assistant\n"
+        base = state["observation"]
+        idx = base.rfind(marker)
+        if idx >= 0:
+            base = base[:idx] + "\n" + room_obs + marker
+        state["observation"] = base + "<think>\n"
+        return state
+
+    async def _drain_stderr(self):
+        assert self.proc is not None and self.proc.stderr is not None
+        while True:
+            line = await self.proc.stderr.readline()
+            if not line:
+                return
+            self._stderr_tail.append(line.decode("utf-8", "replace").rstrip())
+
+    async def _round_trip(self, msg):
+        proc = self.proc
+        if proc is None or proc.stdin is None or proc.stdout is None:
+            raise RuntimeError("alfworld worker is not running")
+
+        async def _exchange():
+            proc.stdin.write((json.dumps(msg) + "\n").encode("utf-8"))
+            await proc.stdin.drain()
+            line = await proc.stdout.readline()
+            if not line:
+                raise RuntimeError(
+                    "alfworld worker closed unexpectedly\n--- worker stderr (tail) ---\n"
+                    + "\n".join(self._stderr_tail)
+                )
+            return json.loads(line.decode("utf-8"))
+
+        try:
+            reply = await asyncio.wait_for(_exchange(), timeout=_STEP_TIMEOUT)
+        except asyncio.TimeoutError:
+            await self.close()
+            raise RuntimeError(f"alfworld worker timed out after {_STEP_TIMEOUT}s on {msg.get('cmd')}")
+        if not reply.get("ok"):
+            await self.close()
+            raise RuntimeError(
+                f"alfworld worker error on {msg.get('cmd')}: {reply.get('error')}\n"
+                + reply.get("traceback", "")
+            )
+        return reply
+
+    async def step(self, state) -> Result:
+        raw = state["action_text"]
+        # Prefer an explicit <action>...</action> tag (robust to quotes, newlines, prose);
+        # fall back to the text after </think> for a model that emits a bare command.
+        if "<action>" in raw and "</action>" in raw:
+            body = raw.split("<action>", 1)[1].split("</action>", 1)[0]
+        else:
+            body = raw.rsplit("</think>", 1)[-1] if "</think>" in raw else raw
+            body = body.replace("<action>", " ").replace("</action>", " ")  # drop stray tags
+        # One clean command: first line, drop a leading "<"/">"/"*"/"-", cut a ">"-chain,
+        # unwrap quotes — TextWorld needs an exact admissible-command match.
+        action = (
+            body.strip().split("\n", 1)[0].lstrip("<>*- ").split(">", 1)[0]
+            .strip().strip('"' + "'" + "`").lower()
+        )
+        self.turn += 1
+        reply = await self._round_trip({"cmd": "step", "action": action})
+        won = bool(reply["won"])
+        truncated = (not won) and self.turn >= _MAX_TURNS
+        reward = torch.tensor(1.0 if won else 0.0, dtype=torch.float32)
+        result = Result(
+            reward=reward,
+            observation=_observation_feedback(reply["obs"], reply["admissible"]),
+            terminated=won,
+            truncated=truncated,
+            info={
+                "alfworld_won": reward,
+                "turn_index": torch.tensor(float(self.turn), dtype=torch.float32),
+            },
+        )
+        # Tear the subprocess down at natural episode end; StepEnvRunner's finally-close
+        # covers the other exit paths (context exhaustion, exceptions). Idempotent.
+        if won or truncated:
+            await self.close()
+        return result
+
+    async def close(self):
+        proc = self.proc
+        stderr_task = self._stderr_task
+        self.proc = None
+        self._stderr_task = None
+        if proc is None:
+            return
+        # Ask the worker to exit cleanly (best effort — it may already be gone).
+        try:
+            if proc.stdin is not None and not proc.stdin.is_closing():
+                proc.stdin.write(b'{"cmd": "close"}\n')
+                await proc.stdin.drain()
+        except Exception:
+            pass
+        try:
+            await asyncio.wait_for(proc.wait(), timeout=_CLOSE_TIMEOUT)
+        except asyncio.TimeoutError:
+            proc.kill()
+            await proc.wait()
+        if stderr_task is not None:
+            stderr_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError, Exception):
+                await stderr_task
+
+    def __del__(self):
+        # Backstop for paths that bypass close() (event loop torn down mid-episode).
+        proc = getattr(self, "proc", None)
+        if proc is not None:
+            try:
+                proc.kill()
+            except Exception:
+                pass
+
+
+class AgentRunner(StepEnvRunner):
+    def __init__(self):
+        super().__init__(AlfWorldEnv)

--- a/examples/python/utils/prepare_alfworld.py
+++ b/examples/python/utils/prepare_alfworld.py
@@ -1,0 +1,184 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Prepare AlfWorld data for Molt: RL game files and SFT expert demos.
+
+Both subcommands need ALFWORLD_DATA on the env (set by `alfworld-download`):
+
+  rl   — walk $ALFWORLD_DATA/<glob> (default json_*/train/**/*.tw-pddl), pair
+          each game with its sibling traj_data.json task description, and emit
+          one jsonl row per game:
+              {"prompt": "<task + usage>", "label": "<abs .tw-pddl path>"}
+          `prompt` is a bare string (the RL script's --data.apply_chat_template
+          wraps it as the user turn); `label` carries the game path the env binds
+          (surfaced to the agent via --data.label_key). A fixed seed splits
+          train/eval in-distribution.
+
+  sft  — read tw_alfred_seq2seq_{train,eval}_task*_hc.json (from
+          `alfworld-download --extra`) and turn each expert episode into a
+          multi-turn chat: user(task + obs0) / assistant(action0) / user(obs1) /
+          assistant(action1) / ... The demo `obs` field is alfworld's pooled
+          seq2seq format ("obs0 [SEP] obs_i [SEP] action_{i-1}"); the current
+          turn's obs is the segment just before the trailing embedded action.
+          Episodes longer than --max-steps are dropped (won't fit the SFT budget).
+
+Output is jsonl (load_dataset-readable via data_files=).
+
+  python examples/python/utils/prepare_alfworld.py rl   --max-train 50   # self-check
+  python examples/python/utils/prepare_alfworld.py sft  --max-train 50
+"""
+
+import argparse
+import json
+import os
+import random
+from pathlib import Path
+
+# One-line usage hint appended to the task instruction. Surfaces the action
+# format and nudges a `look` first — the RL prompt carries no initial room text
+# (reset returns the prompt unchanged), so the model must look to see the room.
+# SFT prep prepends the same hint to its first user turn so the two stay aligned.
+_TASK_SUFFIX = (
+    " You are playing a text household game. On each turn reply with exactly ONE "
+    "short command (e.g. 'go to drawer 1', 'take cd 1', 'open fridge 1', 'use "
+    "lamp 1', 'look'). Start by looking around to see what is in the room."
+)
+
+# RL variant: same task framing but a structured <think>/<action> protocol, so the
+# command is extracted exactly instead of parsed out of free-form text (the model often
+# wraps, prefixes, or chains a bare command). SFT keeps _TASK_SUFFIX so its bare-command
+# targets stay consistent with the expert demos.
+_RL_TASK_SUFFIX = (
+    " You are an expert agent in a text household game. On each turn you are shown the "
+    "current observation and a list of admissible actions. First reason step-by-step "
+    "inside <think> </think> tags, then choose exactly ONE admissible action and put it "
+    "inside <action> </action> tags."
+)
+
+
+def _data_dir() -> Path:
+    data_dir = os.environ.get("ALFWORLD_DATA")
+    assert data_dir, "Set ALFWORLD_DATA (run alfworld-download) before preparing AlfWorld data."
+    return Path(data_dir).expanduser().resolve()
+
+
+def _task_from_traj(gamefile: Path) -> str:
+    traj = json.loads((gamefile.parent / "traj_data.json").read_text(encoding="utf-8"))
+    anns = traj.get("turk_annotations", {}).get("anns") or []
+    if anns and anns[0].get("task_desc"):
+        return anns[0]["task_desc"].strip()
+    return ""
+
+
+def _write_jsonl(path: Path, rows) -> None:
+    with path.open("w", encoding="utf-8") as f:
+        for row in rows:
+            f.write(json.dumps(row, ensure_ascii=False) + "\n")
+
+
+def cmd_rl(args):
+    data_dir = _data_dir()
+    games = sorted(p.resolve() for p in data_dir.glob(args.glob))
+    assert games, f"No .tw-pddl under {data_dir}/{args.glob} — run alfworld-download first."
+
+    rows = []
+    for gamefile in games:
+        task = _task_from_traj(gamefile)
+        if task:
+            rows.append({"prompt": task + _RL_TASK_SUFFIX, "label": str(gamefile)})
+
+    rng = random.Random(args.seed)
+    rng.shuffle(rows)
+    n_eval = int(len(rows) * args.eval_frac)
+    eval_rows, train_rows = rows[:n_eval], rows[n_eval:]
+    if args.max_train:
+        train_rows = train_rows[: args.max_train]
+
+    out_dir = Path(args.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    _write_jsonl(out_dir / "train.jsonl", train_rows)
+    _write_jsonl(out_dir / "eval.jsonl", eval_rows)
+    print(f"alfworld rl: {len(train_rows)} train + {len(eval_rows)} eval games -> {out_dir}")
+
+
+def _clean_obs(obs: str) -> str:
+    # Demo obs are pooled ("obs0 [SEP] obs_i [SEP] action_{i-1}"); the current
+    # turn's obs is the segment just before the trailing embedded action. A clean
+    # first-turn obs has no [SEP] at all.
+    parts = obs.rsplit(" [SEP] ", 2)
+    return (parts[-2] if len(parts) >= 2 else parts[0]).strip()
+
+
+def cmd_sft(args):
+    data_dir = _data_dir()
+    demos = sorted(data_dir.rglob("tw_alfred_seq2seq_*_hc.json"))
+    assert demos, f"No tw_alfred_seq2seq_*_hc.json under {data_dir} — run alfworld-download --extra."
+
+    splits = {"train": [], "eval": []}
+    for demo_file in demos:
+        split = "train" if "_train_" in demo_file.name else "eval" if "_eval_" in demo_file.name else None
+        if split is None:
+            continue
+        for ep in json.loads(demo_file.read_text(encoding="utf-8")).get("data", []):
+            steps = ep.get("steps") or []
+            task = (ep.get("task") or "").strip()
+            if not task or not (1 <= len(steps) <= args.max_steps):
+                continue
+            # user=obs[i], assistant=action[i], paired in order — an off-by-one
+            # here silently trains on the wrong (obs, action) and zeroes win rate.
+            messages = [{"role": "user", "content": f"{task}{_TASK_SUFFIX}\n{_clean_obs(steps[0]['obs'])}"}]
+            for i, step in enumerate(steps):
+                messages.append({"role": "assistant", "content": str(step["action"]).strip()})
+                if i + 1 < len(steps):
+                    messages.append({"role": "user", "content": _clean_obs(steps[i + 1]["obs"])})
+            splits[split].append({"prompt": messages[:-1], "response": [messages[-1]]})
+
+    if args.max_train:
+        splits["train"] = splits["train"][: args.max_train]
+
+    out_dir = Path(args.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    _write_jsonl(out_dir / "train.jsonl", splits["train"])
+    _write_jsonl(out_dir / "eval.jsonl", splits["eval"])
+    print(f"alfworld sft: {len(splits['train'])} train + {len(splits['eval'])} eval episodes -> {out_dir}")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Prepare AlfWorld data for Molt (RL game files / SFT expert demos).",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    rl = sub.add_parser("rl", help="Emit game-file rows for RL (prompt + .tw-pddl label).")
+    rl.add_argument("--out-dir", default=".tmp/alfworld_rl")
+    rl.add_argument("--glob", default="json_*/train/**/*.tw-pddl", help="Glob under ALFWORLD_DATA for game files.")
+    rl.add_argument("--eval-frac", type=float, default=0.05)
+    rl.add_argument("--seed", type=int, default=0)
+    rl.add_argument("--max-train", type=int, default=None)
+    rl.set_defaults(func=cmd_rl)
+
+    sft = sub.add_parser("sft", help="Emit multi-turn chat episodes from expert demos.")
+    sft.add_argument("--out-dir", default=".tmp/alfworld_sft")
+    sft.add_argument("--max-steps", type=int, default=40, help="Drop episodes longer than this.")
+    sft.add_argument("--max-train", type=int, default=None)
+    sft.set_defaults(func=cmd_sft)
+
+    args = parser.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/scripts/quick_start/rl_qwen3_4b_alfworld.sh
+++ b/examples/scripts/quick_start/rl_qwen3_4b_alfworld.sh
@@ -1,0 +1,137 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Single-node quick-start: Qwen3-4B multi-turn RL on AlfWorld (TextWorld).
+#
+# Point MODEL_PATH at the SFT warmstart checkpoint (sft_qwen3_4b_alfworld.sh) —
+# pure-RL cold start has no signal here (0/1 terminal reward, ~0% base win rate).
+# Each turn the agent emits one NL command; the env steps the game and feeds the
+# new observation back as a ChatML user turn. n_samples_per_prompt=8 rolls the
+# SAME game 8 times so a GRPO group has a win/loss spread to contrast on.
+#
+# Prereq (one-time):
+#   pip install alfworld textworld[gym]
+#   export ALFWORLD_DATA=$HOME/.molt_data/alfworld
+#   alfworld-download
+#   python examples/python/utils/prepare_alfworld.py rl
+#
+#   MODEL_PATH=<sft checkpoint> bash examples/scripts/quick_start/rl_qwen3_4b_alfworld.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${MOLT_PATH:-$(cd "$SCRIPT_DIR/../../.." && pwd)}"
+MODEL_PATH="${MODEL_PATH:?Set MODEL_PATH to the AlfWorld SFT checkpoint (run sft_qwen3_4b_alfworld.sh first).}"
+
+PROMPT_DATASET="${PROMPT_DATASET:-$REPO_ROOT/.tmp/alfworld_rl/train.jsonl}"
+EVAL_DATASET="${EVAL_DATASET:-$REPO_ROOT/.tmp/alfworld_rl/eval.jsonl}"
+test -e "$PROMPT_DATASET" || { echo "PROMPT_DATASET not found: $PROMPT_DATASET — run: python examples/python/utils/prepare_alfworld.py rl"; exit 1; }
+SAVE_ROOT="${SAVE_ROOT:-$REPO_ROOT/outputs/quick_start-rl-qwen3-4b-alfworld/run}"
+
+GPUS_PER_NODE="${GPUS_PER_NODE:-8}"
+ACTOR_GPUS="${ACTOR_GPUS:-4}"
+VLLM_TP="${VLLM_TP:-4}"
+
+export HF_HOME="${HF_HOME:-$HOME/.cache/huggingface}"
+export TOKENIZERS_PARALLELISM=true
+export RAY_USAGE_STATS_ENABLED=0
+export VLLM_WORKER_MULTIPROC_METHOD=spawn
+export VLLM_USE_FLASHINFER_MOE_FP16=0
+export PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
+# Agent reads MAX_AGENT_TURNS; AlfWorld games need ~15-30 commands.
+export MAX_AGENT_TURNS="${MAX_AGENT_TURNS:-30}"
+# Dedicated TextWorld thread pool — raise toward rollout concurrency if steps stall.
+export ALFWORLD_TW_WORKERS="${ALFWORLD_TW_WORKERS:-8}"
+# Offline by default — flip WANDB_MODE=online to log remotely.
+export WANDB_MODE="${WANDB_MODE:-offline}"
+# wandb appends its own wandb/ subdir -> point WANDB_DIR at $SAVE_ROOT, not .../wandb.
+export WANDB_DIR="${WANDB_DIR:-$SAVE_ROOT}"
+
+# Ray session logs land at /tmp/ray/session_latest/logs/ (not under $SAVE_ROOT):
+# ray's plasma_store socket lives under --temp-dir and is capped at 107 bytes
+# (AF_UNIX), so a deep outputs/... path overruns it and ray start fails.
+if ! ray status >/dev/null 2>&1; then
+  ray start --head --num-gpus="$GPUS_PER_NODE" --disable-usage-stats >/dev/null
+  STARTED_RAY=1
+else
+  STARTED_RAY=0
+fi
+trap '[ "$STARTED_RAY" = "1" ] && ray stop --force >/dev/null 2>&1 || true' EXIT
+
+cd "$REPO_ROOT"
+# n_samples_per_prompt=8 forms a GRPO group per game (sparse-reward signal source);
+# max_new_tokens=32 (commands are short); max_len=16384 fits ~50 obs/action turns.
+python3 -u -m molt.cli.train_rl_ray \
+  --actor.model_name_or_path "$MODEL_PATH" \
+  --data.prompt_dataset "$PROMPT_DATASET" \
+  --data.input_key prompt \
+  --data.label_key label \
+  --data.apply_chat_template \
+  --data.max_samples "${MAX_SAMPLES:-4800}" \
+  --data.max_len "${MAX_LEN:-16384}" \
+  --rollout.batch_size "${ROLLOUT_BATCH:-16}" \
+  --rollout.vllm_generate_batch_size "${VLLM_GEN_BATCH:-4}" \
+  --rollout.micro_batch_size 1 \
+  --rollout.n_samples_per_prompt 8 \
+  --rollout.max_new_tokens "${MAX_NEW_TOKENS:-32}" \
+  --rollout.temperature 1.0 \
+  --train.batch_size 128 \
+  --train.micro_batch_size 1 \
+  --train.max_epochs 1 \
+  --train.num_episodes 1 \
+  --train.async_queue_size 2 \
+  --train.colocate_fsdp_models \
+  --actor.num_nodes 1 \
+  --actor.num_gpus_per_node "$ACTOR_GPUS" \
+  --ref.num_nodes 1 \
+  --ref.num_gpus_per_node "$ACTOR_GPUS" \
+  --vllm.num_engines 1 \
+  --vllm.tensor_parallel_size "$VLLM_TP" \
+  --vllm.sync_backend nccl \
+  --vllm.gpu_memory_utilization 0.8 \
+  --vllm.disable_custom_all_reduce \
+  --vllm.distributed_executor_backend mp \
+  --fsdp.param_dtype bf16 \
+  --fsdp.attn_implementation flash_attention_2 \
+  --fsdp.tp_size 1 \
+  --fsdp.ep_size 1 \
+  --fsdp.cp_size 1 \
+  --fsdp.packing_samples \
+  --actor.gradient_checkpoint full \
+  --actor.adam.lr 1e-6 \
+  --actor.eps_clip_low_high 0.2 0.27 \
+  --actor.dual_clip 10.0 \
+  --algo.advantage.estimator reinforce_baseline \
+  --algo.advantage.is_correction_level geo \
+  --algo.advantage.is_correction_threshold 0.99 1.01 \
+  --algo.kl.use_loss \
+  --algo.kl.estimator k2 \
+  --algo.kl.init_coef 0.001 \
+  --algo.dynamic_filtering_enable \
+  --algo.dynamic_filtering_range 0.01 0.99 \
+  --reward.clip_range -10 10 \
+  --train.agent_path "$REPO_ROOT/examples/python/agents/alfworld.py" \
+  --eval.dataset "$EVAL_DATASET" \
+  --eval.steps 5 \
+  --eval.n_samples_per_prompt 1 \
+  --ckpt.output_dir "$SAVE_ROOT/hf" \
+  --ckpt.path "$SAVE_ROOT/state" \
+  --ckpt.save_steps 5 \
+  --logger.logging_steps 1 \
+  --logger.wandb.key "${WANDB_KEY:-local}" \
+  --logger.wandb.project "${WANDB_PROJECT:-molt_alfworld_rl_qwen3_4b}" \
+  --logger.wandb.run_name "${WANDB_RUN_NAME:-qwen3_4b_alfworld_rl_$$}" \
+  --logger.tensorboard_dir "$SAVE_ROOT/tb"

--- a/examples/scripts/quick_start/sft_qwen3_4b_alfworld.sh
+++ b/examples/scripts/quick_start/sft_qwen3_4b_alfworld.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Single-node quick-start: Qwen3-4B SFT warmstart on AlfWorld expert demos.
+#
+# Warmstart is required, not optional: AlfWorld reward is a 0/1 terminal signal
+# and the base model wins ~0%, so pure RL has no in-group win/loss contrast to
+# learn from. SFT on the handcoded-expert demos (alfworld-download --extra) lifts
+# the win rate to ~10-30%, giving GRPO groups a spread to bootstrap from.
+#
+# Prereq (one-time):
+#   pip install alfworld textworld[gym]
+#   export ALFWORLD_DATA=$HOME/.molt_data/alfworld
+#   alfworld-download            # game .tw-pddl + traj_data.json
+#   alfworld-download --extra    # seq2seq expert demos (consumed below)
+#   python examples/python/utils/prepare_alfworld.py sft
+#
+#   MODEL_PATH=/path/to/Qwen3-4B-Instruct-2507 bash examples/scripts/quick_start/sft_qwen3_4b_alfworld.sh
+# Point the follow-up RL run at this run's checkpoint (outputs/.../hf).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${MOLT_PATH:-$(cd "$SCRIPT_DIR/../../.." && pwd)}"
+MODEL_PATH="${MODEL_PATH:-/path/to/models/Qwen3/Qwen3-4B-Instruct-2507}"
+
+SFT_DATASET="${SFT_DATASET:-$REPO_ROOT/.tmp/alfworld_sft/train.jsonl}"
+EVAL_DATASET="${EVAL_DATASET:-$REPO_ROOT/.tmp/alfworld_sft/eval.jsonl}"
+test -e "$SFT_DATASET" || { echo "SFT_DATASET not found: $SFT_DATASET — run: python examples/python/utils/prepare_alfworld.py sft"; exit 1; }
+SAVE_ROOT="${SAVE_ROOT:-$REPO_ROOT/outputs/quick_start-sft-qwen3-4b-alfworld/run}"
+
+GPUS_PER_NODE="${GPUS_PER_NODE:-8}"
+TP_SIZE="${TP_SIZE:-1}"
+EP_SIZE="${EP_SIZE:-1}"
+CP_SIZE="${CP_SIZE:-1}"
+MAX_LEN="${MAX_LEN:-8192}"            # multi-turn demos: task + up to ~40 obs/action turns
+TRAIN_BATCH_SIZE="${TRAIN_BATCH_SIZE:-32}"
+MICRO_BATCH_SIZE="${MICRO_BATCH_SIZE:-1}"   # long multi-turn sequences
+MAX_SAMPLES="${MAX_SAMPLES:-4096}"
+
+export HF_HOME="${HF_HOME:-$HOME/.cache/huggingface}"
+export TOKENIZERS_PARALLELISM=true
+export PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
+# Offline by default — flip WANDB_MODE=online (and set WANDB_API_KEY) to log remotely.
+export WANDB_MODE="${WANDB_MODE:-offline}"
+# wandb appends its own wandb/ subdir -> point WANDB_DIR at $SAVE_ROOT, not .../wandb.
+export WANDB_DIR="${WANDB_DIR:-$SAVE_ROOT}"
+
+cd "$REPO_ROOT"
+torchrun --standalone --nproc_per_node="$GPUS_PER_NODE" -m molt.cli.train_sft \
+  --data.max_len "$MAX_LEN" \
+  --data.dataset "$SFT_DATASET" \
+  --data.input_key prompt \
+  --data.output_key response \
+  --data.max_samples "$MAX_SAMPLES" \
+  --model.model_name_or_path "$MODEL_PATH" \
+  --ckpt.output_dir "$SAVE_ROOT/hf" \
+  --ckpt.path "$SAVE_ROOT/state" \
+  --ckpt.save_steps "${SAVE_STEPS:-50}" \
+  --logger.logging_steps 1 \
+  --eval.dataset "$EVAL_DATASET" \
+  --eval.steps "${EVAL_STEPS:-20}" \
+  --train.max_epochs "${MAX_EPOCHS:-3}" \
+  --train.batch_size "$TRAIN_BATCH_SIZE" \
+  --train.micro_batch_size "$MICRO_BATCH_SIZE" \
+  --fsdp.param_dtype bf16 \
+  --fsdp.attn_implementation "${FSDP_ATTN_IMPLEMENTATION:-flash_attention_2}" \
+  --fsdp.tp_size "$TP_SIZE" \
+  --fsdp.ep_size "$EP_SIZE" \
+  --fsdp.cp_size "$CP_SIZE" \
+  --model.gradient_checkpoint full \
+  --adam.lr "${LR:-1e-6}" \
+  --logger.wandb.key "${WANDB_KEY:-local}" \
+  --logger.wandb.project "${WANDB_PROJECT:-molt_alfworld_sft_qwen3_4b}" \
+  --logger.wandb.run_name "${WANDB_RUN_NAME:-qwen3_4b_alfworld_sft_$$}" \
+  --logger.tensorboard_dir "$SAVE_ROOT/tb"

--- a/molt/agents/base.py
+++ b/molt/agents/base.py
@@ -238,6 +238,12 @@ class Env(ABC):
         """
         raise NotImplementedError
 
+    async def close(self):
+        """Optional per-episode teardown. StepEnvRunner calls this on every exit
+        path (episode end, context exhaustion, exception) — override to release
+        OS resources such as subprocesses or VMs. Default: no-op."""
+        pass
+
 
 # ---------------------------------------------------------------------------
 # Runner — abstract base for "produce one Trajectory per execute() call".
@@ -308,120 +314,128 @@ class StepEnvRunner(Runner):
         # render features resolve where it generates. Per-rollout, like vime/slime.
         rollout_sid = uuid4().hex
 
-        reset = await env.reset({"observation": prompt, "label": label})
-        observation_text = reset["observation"]
+        try:
+            reset = await env.reset({"observation": prompt, "label": label})
+            observation_text = reset["observation"]
 
-        # process_prompt_with_images (inside _tokenize_observation) is a multi-second CPU op per image.
-        # run_group gathers n_samples rollouts on ONE actor event loop, so a synchronous tokenize
-        # blocks the loop and serializes the group (+ stalls the others' awaited generations). Run it
-        # in a thread so the loop stays free and rollouts overlap (mirrors the chat server).
-        obs_tokens, mm_train_inputs, pil_images = await asyncio.get_running_loop().run_in_executor(
-            _TOKENIZE_EXECUTOR, _tokenize_observation, hf_tokenizer, observation_text, images
-        )
-        image_budget = 0
-        if pil_images:
-            from molt.utils.vlm_utils import estimate_vllm_input_expansion_delta
-
-            image_budget = estimate_vllm_input_expansion_delta(hf_tokenizer, obs_tokens, mm_train_inputs, pil_images)
-
-        generation_reserve = sampling_params.max_tokens or 32
-        max_initial_length = max(1, max_length - generation_reserve - image_budget)
-        if len(obs_tokens) > max_initial_length:
+            # process_prompt_with_images (inside _tokenize_observation) is a multi-second CPU op per image.
+            # run_group gathers n_samples rollouts on ONE actor event loop, so a synchronous tokenize
+            # blocks the loop and serializes the group (+ stalls the others' awaited generations). Run it
+            # in a thread so the loop stays free and rollouts overlap (mirrors the chat server).
+            obs_tokens, mm_train_inputs, pil_images = await asyncio.get_running_loop().run_in_executor(
+                _TOKENIZE_EXECUTOR, _tokenize_observation, hf_tokenizer, observation_text, images
+            )
+            image_budget = 0
             if pil_images:
-                raise ValueError(
-                    f"VLM prompt length ({len(obs_tokens)}) exceeds max_initial_length ({max_initial_length}). "
-                    "Truncating VLM prompts would break image token alignment with pixel_values. "
-                    "Please increase --max_len or decrease --max_new_tokens."
+                from molt.utils.vlm_utils import estimate_vllm_input_expansion_delta
+
+                image_budget = estimate_vllm_input_expansion_delta(
+                    hf_tokenizer, obs_tokens, mm_train_inputs, pil_images
                 )
-            logger.warning(
-                f"Initial observation length ({len(obs_tokens)}) exceeds max_initial_length "
-                f"({max_initial_length}). Truncating to fit within max_length ({max_length})."
+
+            generation_reserve = sampling_params.max_tokens or 32
+            max_initial_length = max(1, max_length - generation_reserve - image_budget)
+            if len(obs_tokens) > max_initial_length:
+                if pil_images:
+                    raise ValueError(
+                        f"VLM prompt length ({len(obs_tokens)}) exceeds max_initial_length ({max_initial_length}). "
+                        "Truncating VLM prompts would break image token alignment with pixel_values. "
+                        "Please increase --max_len or decrease --max_new_tokens."
+                    )
+                logger.warning(
+                    f"Initial observation length ({len(obs_tokens)}) exceeds max_initial_length "
+                    f"({max_initial_length}). Truncating to fit within max_length ({max_length})."
+                )
+                obs_tokens = obs_tokens[-max_initial_length:]
+                observation_text = hf_tokenizer.decode(obs_tokens, skip_special_tokens=False)
+
+            trajectory = Trajectory(
+                prompt=prompt,
+                label=label,
+                images=images,
+                observation_text=observation_text,
+                observation_tokens=obs_tokens,
+                mm_train_inputs=mm_train_inputs,
+                pil_images=pil_images,
+                image_budget=image_budget,
+                rollout_log_probs=[0.0] * len(obs_tokens) if sampling_params.logprobs is not None else None,
             )
-            obs_tokens = obs_tokens[-max_initial_length:]
-            observation_text = hf_tokenizer.decode(obs_tokens, skip_special_tokens=False)
 
-        trajectory = Trajectory(
-            prompt=prompt,
-            label=label,
-            images=images,
-            observation_text=observation_text,
-            observation_tokens=obs_tokens,
-            mm_train_inputs=mm_train_inputs,
-            pil_images=pil_images,
-            image_budget=image_budget,
-            rollout_log_probs=[0.0] * len(obs_tokens) if sampling_params.logprobs is not None else None,
-        )
+            # Per-turn cap; remaining context dominates if smaller.
+            per_turn_cap = sampling_params.max_tokens
 
-        # Per-turn cap; remaining context dominates if smaller.
-        per_turn_cap = sampling_params.max_tokens
+            while True:
+                remaining = max_length - len(trajectory.observation_tokens) - trajectory.image_budget
+                turn_sp = deepcopy(sampling_params)
+                turn_sp.max_tokens = min(per_turn_cap, remaining) if per_turn_cap is not None else remaining
+                if turn_sp.max_tokens <= 0:
+                    trajectory.truncated = True
+                    break
+                # A late turn's remaining budget can drop below a configured min_tokens;
+                # vLLM only validates min<=max at construction, not on reassignment.
+                min_tokens = getattr(turn_sp, "min_tokens", None)
+                if min_tokens is not None and min_tokens > turn_sp.max_tokens:
+                    turn_sp.min_tokens = turn_sp.max_tokens
 
-        while True:
-            remaining = max_length - len(trajectory.observation_tokens) - trajectory.image_budget
-            turn_sp = deepcopy(sampling_params)
-            turn_sp.max_tokens = min(per_turn_cap, remaining) if per_turn_cap is not None else remaining
-            if turn_sp.max_tokens <= 0:
-                trajectory.truncated = True
-                break
-            # A late turn's remaining budget can drop below a configured min_tokens;
-            # vLLM only validates min<=max at construction, not on reassignment.
-            min_tokens = getattr(turn_sp, "min_tokens", None)
-            if min_tokens is not None and min_tokens > turn_sp.max_tokens:
-                turn_sp.min_tokens = turn_sp.max_tokens
+                mm_data = {"image": trajectory.pil_images} if trajectory.pil_images else None
+                request_output, off_policy_len = await llm_engine.generate(
+                    trajectory.observation_tokens, turn_sp, multi_modal_data=mm_data, session_id=rollout_sid
+                )
+                generation = request_output.outputs[0]
+                action_tokens = generation.token_ids
+                # /inference/v1/generate is token-only (generation.text == ""); decode from the ids so
+                # Env.step sees the action text. skip_special_tokens=False keeps answer markers (<answer>,
+                # \boxed, tool tags) — matches observation_text decoding above.
+                action_text = generation.text or (
+                    hf_tokenizer.decode(action_tokens, skip_special_tokens=False) if action_tokens else ""
+                )
+                trajectory.truncated = trajectory.truncated or generation.finish_reason == "length"
 
-            mm_data = {"image": trajectory.pil_images} if trajectory.pil_images else None
-            request_output, off_policy_len = await llm_engine.generate(
-                trajectory.observation_tokens, turn_sp, multi_modal_data=mm_data, session_id=rollout_sid
-            )
-            generation = request_output.outputs[0]
-            action_tokens = generation.token_ids
-            # /inference/v1/generate is token-only (generation.text == ""); decode from the ids so
-            # Env.step sees the action text. skip_special_tokens=False keeps answer markers (<answer>,
-            # \boxed, tool tags) — matches observation_text decoding above.
-            action_text = generation.text or (
-                hf_tokenizer.decode(action_tokens, skip_special_tokens=False) if action_tokens else ""
-            )
-            trajectory.truncated = trajectory.truncated or generation.finish_reason == "length"
+                result: Result = await env.step(
+                    {
+                        "observation_text": trajectory.observation_text,
+                        "action_text": action_text,
+                        "label": label,
+                        "sampling_params": deepcopy(turn_sp),
+                    }
+                )
+                if not isinstance(result, Result):
+                    raise TypeError(f"Env.step must return a Result, got {type(result).__name__}")
 
-            result: Result = await env.step(
-                {
-                    "observation_text": trajectory.observation_text,
-                    "action_text": action_text,
-                    "label": label,
-                    "sampling_params": deepcopy(turn_sp),
-                }
-            )
-            if not isinstance(result, Result):
-                raise TypeError(f"Env.step must return a Result, got {type(result).__name__}")
+                reward_val = _first_scalar(result.reward)
+                if reward_val is None:
+                    raise ValueError("Env.step must return a Result with a scalar reward.")
+                score_val = _first_scalar(result.score) if result.score is not None else reward_val
 
-            reward_val = _first_scalar(result.reward)
-            if reward_val is None:
-                raise ValueError("Env.step must return a Result with a scalar reward.")
-            score_val = _first_scalar(result.score) if result.score is not None else reward_val
+                trajectory.reward += reward_val
+                trajectory.scores = score_val
+                trajectory.extra_logs = result.info or {}
 
-            trajectory.reward += reward_val
-            trajectory.scores = score_val
-            trajectory.extra_logs = result.info or {}
+                action_logprobs = None
+                if trajectory.rollout_log_probs is not None:
+                    action_logprobs = _extract_generation_logprobs(action_tokens, generation.logprobs)
+                trajectory.append_action(action_tokens, action_logprobs, off_policy_len=off_policy_len)
+                trajectory.absorb_routing(request_output)  # fills routing by absolute position (R3)
 
-            action_logprobs = None
-            if trajectory.rollout_log_probs is not None:
-                action_logprobs = _extract_generation_logprobs(action_tokens, generation.logprobs)
-            trajectory.append_action(action_tokens, action_logprobs, off_policy_len=off_policy_len)
-            trajectory.absorb_routing(request_output)  # fills routing by absolute position (R3)
+                feedback_tokens = _tokenize_feedback(
+                    hf_tokenizer, result.observation, result.images, trajectory, max_length
+                )
+                trajectory.append_feedback(action_text, result.observation, feedback_tokens)
 
-            feedback_tokens = _tokenize_feedback(
-                hf_tokenizer, result.observation, result.images, trajectory, max_length
-            )
-            trajectory.append_feedback(action_text, result.observation, feedback_tokens)
+                if result.sampling_params is not None:
+                    sampling_params = deepcopy(result.sampling_params)
+                    per_turn_cap = sampling_params.max_tokens
 
-            if result.sampling_params is not None:
-                sampling_params = deepcopy(result.sampling_params)
-                per_turn_cap = sampling_params.max_tokens
+                if result.terminated or result.truncated:
+                    trajectory.truncated = trajectory.truncated or result.truncated
+                    break
 
-            if result.terminated or result.truncated:
-                trajectory.truncated = trajectory.truncated or result.truncated
-                break
-
-        return trajectory
+            return trajectory
+        finally:
+            # An env can own OS resources (alfworld runs one textworld subprocess per episode), and
+            # episodes routinely exit without step() ever returning terminated/truncated (context
+            # exhaustion, exceptions) — close here so teardown never depends on the env's own GC.
+            await env.close()
 
 
 def _tokenize_feedback(hf_tokenizer, feedback_text: str, new_images, trajectory: Trajectory, max_length: int):


### PR DESCRIPTION
  ## Problem

  An `Env` may own OS-level resources whose lifetime spans one episode — a subprocess
  per game, a VM, a browser. But episodes routinely exit **without** `Env.step` ever
  returning `terminated/truncated`:

  - the runner truncates on **context exhaustion** (`max_tokens` budget hits zero → `break`),
  - any raise in `reset`/`step`/tokenize **aborts the loop**.

  On those paths, cleanup left to the env itself only runs under `__del__` — whose
  timing is arbitrary, and which typically only kills without reaping.

  ## Change

  - Add an optional `async Env.close()` hook (default no-op).
  - Wrap `StepEnvRunner.execute`'s body in `try/finally` so `close()` is awaited on
    **every** exit path. No behavior change for envs that don't override `close()`.

  ## Example: AlfWorld (commit 2)

  A complete integration whose env consumes the contract:

  - **One TextWorld subprocess per episode** (JSON-lines `init|step|close` over
    stdin/stdout). The tatsu grammar parser keeps process-wide parse state, so
    multiple games in one process corrupt each other even when serialized — the OS
    is the only reliable fence. The parent never imports textworld.
  - `close()` is idempotent — called at natural episode end from `step()`, and on
    every other exit path by the runner's `finally`. Without it, leaked subprocesses
    accumulate until fd/memory exhaustion stalls the whole rollout (observed as
    rollouts hanging after a few hours; `ps aux | grep python | wc -l` climbing
    without bound).
  - `prepare_alfworld.py` (`rl` gamefile-as-label / `sft` expert demos) + SFT/RL
    quick-start recipes. SFT warmstart is required: 0/1 terminal reward means
    cold-start GRPO has no in-group win/loss contrast to learn from.
  - Prompt protocol: `<think>...</think>` reasoning + exactly one admissible command
    in `<action>...</action>`; the env seeds the opening `<think>` and extracts the
    command exactly, with a bare-command fallback.

  ## Testing

  - `pytest tests/unit/test_agents_base.py tests/unit/test_chat_agent.py` — 7 passed.
  - `bash -n` on both recipes; `python -m compileall`; ruff line-length clean.
  - Ran the full RL path on a 8*a800 dev box (Qwen3-1.7B).