### PR TITLE
fix(eval): count each episode once in pass@k

### DIFF
--- a/molt/trainer/rl_trainer.py
+++ b/molt/trainer/rl_trainer.py
@@ -190,6 +190,7 @@ def compute_eval_metrics(eval_dataloader, samples_list, n_samples_per_prompt):
     grouped: Dict[str, Dict[str, list]] = {}
     group_order = []
     group_prompt: Dict[str, str] = {}
+    seen_episodes = set()
     for s in samples_list:
         prompt = s.prompts[0]
         key = s.group_ids[0] if getattr(s, "group_ids", None) else prompt
@@ -197,7 +198,14 @@ def compute_eval_metrics(eval_dataloader, samples_list, n_samples_per_prompt):
             grouped[key] = {"rewards": [], "lengths": [], "truncated": []}
             group_order.append(key)
             group_prompt[key] = prompt
-        grouped[key]["rewards"].append(_first_scalar(s.rewards))
+        # Multi-turn flatten emits one sample per trajectory segment, each repeating the
+        # episode-level reward — count each episode (rollout_id) once, or pass@k becomes
+        # turn-weighted and long failing episodes dominate. Lengths/truncated stay
+        # per-segment on purpose (they measure generated text, not episodes).
+        episode = (key, s.rollout_ids[0] if getattr(s, "rollout_ids", None) else id(s))
+        if episode not in seen_episodes:
+            seen_episodes.add(episode)
+            grouped[key]["rewards"].append(_first_scalar(s.rewards))
         grouped[key]["lengths"].append(_first_scalar(s.response_length))
         grouped[key]["truncated"].append(_first_scalar(s.truncated))
 

--- a/tests/unit/test_prompts_dataset.py
+++ b/tests/unit/test_prompts_dataset.py
@@ -147,3 +147,23 @@ def test_eval_metrics_maps_chat_list_prompts_to_datasource():
     )
     metrics = compute_eval_metrics(eval_dataloader, [sample], n_samples_per_prompt=1)
     assert metrics["eval_geo3k_pass1"] == 1.0  # datasource resolved via the last user turn text
+
+
+def test_eval_metrics_counts_each_episode_once_across_turn_segments():
+    # Multi-turn flatten emits one sample per trajectory segment, all repeating the
+    # episode reward. A failing episode runs to the step cap (many segments) while a
+    # successful one stops early, so segment-averaging would read (0+0+0+1)/4 = 0.25
+    # here. Deduping by rollout_id must read the true episode mean (0+1)/2 = 0.5.
+    eval_dataloader = [(["geo3k"], [ROW["prompt"]], ["42"], [None], [None])]
+    seg = lambda rid, reward: SimpleNamespace(  # noqa: E731
+        prompts=["<image>\nWhat is x?"],
+        group_ids=["g1"],
+        rollout_ids=[rid],
+        rewards=[reward],
+        response_length=[7],
+        truncated=[False],
+    )
+    samples = [seg("fail", 0.0), seg("fail", 0.0), seg("fail", 0.0), seg("ok", 1.0)]
+    metrics = compute_eval_metrics(eval_dataloader, samples, n_samples_per_prompt=2)
+    assert metrics["eval_geo3k_pass1"] == 0.5  # episode mean, not turn-weighted
+    assert metrics["eval_geo3k_pass2"] == 1.0


### PR DESCRIPTION
Multi-turn flatten emits one sample per trajectory segment, each repeating the episode-level reward, so compute_eval_metrics averaged over segments: pass@k was turn-weighted and long failing episodes dominated (~2pt pass1 deflation measured on an OSWorld-361 eval). Dedupe rewards by (group_id, rollout_id) so pass1/pass@k are true episode means; lengths/truncated stay per-segment since they measure generated text. Single-turn tasks are unaffected (one segment per episode).