### PR TITLE
fix(rollout): dataset not divisible by rollout.batch_size never ends epoch

### DIFF
--- a/molt/trainer/rollout/samples_generator.py
+++ b/molt/trainer/rollout/samples_generator.py
@@ -199,7 +199,14 @@ class SamplesGenerator:
         a weight refit pauses/resumes the engines (see broadcast_to_vllm), so the
         in-flight rollouts survive it.
         """
-        if getattr(self, "_dataloader_iter", None) is None:
+        # Rebuild only on a genuinely fresh round (first call, or a new episode after the
+        # previous round's exhausted=True emptied the pool). An EXHAUSTED iterator is also
+        # None; rebuilding it here would restart the epoch mid-stream and drop the in-flight tail.
+        if (
+            getattr(self, "_dataloader_iter", None) is None
+            and not getattr(self, "_inflight_rollouts", None)
+            and not getattr(self, "_finished_samples", None)
+        ):
             self._dataloader_iter = iter(self.prompts_dataloader)
             # Seed from a warm-resume buffer if load_state_dict restored one, so the first
             # post-resume batch ships without waiting for a full fresh generation. Consumed once.

--- a/tests/unit/test_samples_generator.py
+++ b/tests/unit/test_samples_generator.py
@@ -202,6 +202,37 @@ def test_generate_samples_pool_persists_across_calls(monkeypatch):
     assert [handle.group_id for handle in generator._inflight_rollouts] == ["p6", "p7", "p8", "p9"]
 
 
+def test_generate_samples_terminates_when_dataset_not_divisible_by_batch(monkeypatch):
+    """A dataset size not divisible by rollout.batch_size must still end its epoch.
+
+    The dataloader drains mid-call while rollouts are still in flight; that exhausted
+    iterator (None) with a non-empty pool must NOT be mistaken for a fresh round, which
+    used to rebuild the iterator, drop the in-flight tail, and restart the epoch forever.
+    """
+    generator = object.__new__(SamplesGenerator)
+    generator.args = SimpleNamespace(
+        rollout=SimpleNamespace(batch_size=3, n_samples_per_prompt=1, vllm_generate_batch_size=5),
+        algo=SimpleNamespace(dynamic_filtering_enable=False),
+        ckpt=SimpleNamespace(warm_resume_rollouts=False),
+    )
+    generator.prompts_dataloader = _prompt_loader(7)  # 7 % 3 != 0
+    _wire_fake_vllm(generator, monkeypatch, _sample)
+
+    first, _, _, exhausted1 = generator.generate_samples()
+    second, _, _, exhausted2 = generator.generate_samples()
+    third, _, _, exhausted3 = generator.generate_samples()
+
+    # Three batches tile the 7 prompts exactly once: 3 + 3 + 1, and the last call
+    # (which serves the in-flight tail with the dataloader already exhausted) ends
+    # the epoch instead of restarting it from p0.
+    assert [s.group_ids[0] for s in first] == ["p0", "p1", "p2"]
+    assert [s.group_ids[0] for s in second] == ["p3", "p4", "p5"]
+    assert [s.group_ids[0] for s in third] == ["p6"]
+    assert exhausted1 is False and exhausted2 is False
+    assert exhausted3 is True
+    assert generator._inflight_rollouts == [] and generator._finished_samples == []
+
+
 def test_generator_keeps_no_checkpoint_state_and_resumes_from_dataloader(monkeypatch):
     """The in-flight pool is intentionally NOT persisted.
 


### PR DESCRIPTION
## Problem

When the prompt-dataset size (`--data.max_samples`, or any dataset that isn't a multiple) is **not divisible** by `--rollout.batch_size`, the training loop never finishes the epoch: it restarts from the first prompt forever and re-trains the same batch repeatedly. It also triggers with `vllm_generate_batch_size > rollout.batch_size` regardless of divisibility.

Reproduced by driving the real `SamplesGenerator` through the fit-loop queue/slot handshake:

| dataset / batch | before | after |
|---|---|---|
| 32 / 16 (divisible) | 2 batches [16, 16], ends | unchanged |
| 30 / 16 | infinite loop, re-trains p0–p15 forever | [16, 14], each prompt trained once, ends |
| 20 / 16 | infinite loop | [16, 4], ends |
| 10 / 16 (dataset < batch) | [10], ends | unchanged |
| 30 / 16, gen batch 32 | infinite loop | [16, 14], ends |

## Root cause

Two interacting issues in `SamplesGenerator.generate_samples`:

1. The dataloader drains **mid-call** while rollouts are still in flight (streaming refills one prompt per completion). The `exhausted` flag correctly stays `False` then — the in-flight tail is still pending data.
2. On the next call, the iterator-rebuild condition (`_dataloader_iter is None`) mistakes **exhausted** for **fresh round**: it rebuilds the iterator (epoch restarts at prompt 0), resets `_finished_samples`, and drops the in-flight tail (`_inflight_rollouts = []`). `exhausted` can then never become `True`, so `GenerateSamplesActor.fit` never breaks → the epoch restarts forever, discarding the already-generated tail rollouts each round.

A divisible dataset only works by luck: with refills of one prompt each, the exhaustion signal surfaces on the very call where the tail plus the last prompt still tile into full batches.

## Fix

Rebuild the iterator only on a genuinely fresh round — when the pool is empty too (no in-flight rollouts, no buffered groups). First call, the per-episode rebuild (previous round ended with `exhausted=True`), and warm-resume seeding behave exactly as before.

## Test

`test_generate_samples_terminates_when_dataset_not_divisible_by_batch`: 7 prompts / batch 3 / gen batch 5 walks precisely into the exhausted-with-inflight-tail state; asserts batches [p0–p2], [p3–p5], [p6] tile the dataset exactly once and the final call returns `exhausted=True` (the old code restarts from p0 here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)