### PR TITLE
fix(docker): docker_run.sh crashing and exposing HF_TOKEN

### DIFF
--- a/examples/scripts/docker_run.sh
+++ b/examples/scripts/docker_run.sh
@@ -35,11 +35,16 @@ else
 fi
 
 ENV_FLAGS=()
+# Pass env vars by name only (docker reads the value from the host env) and
+# keep xtrace off while expanding them, so tokens never hit the trace, shell
+# history, or `ps` output.
+{ set +x; } 2>/dev/null
 for ENV_NAME in CUDA_VISIBLE_DEVICES FLASHINFER_WORKSPACE_BASE FLASHINFER_WORKSPACE_DIR HF_HOME HF_TOKEN HUGGING_FACE_HUB_TOKEN PYTORCH_CUDA_ALLOC_CONF; do
 	if [[ -n "${!ENV_NAME:-}" ]]; then
-		ENV_FLAGS+=(-e "$ENV_NAME=${!ENV_NAME}")
+		ENV_FLAGS+=(-e "$ENV_NAME")
 	fi
 done
+set -x
 
 docker run --runtime=nvidia --gpus "$DOCKER_GPUS" "${TTY_FLAGS[@]}" --rm --shm-size="$DOCKER_SHM_SIZE" --cap-add=SYS_ADMIN \
 	"${ENV_FLAGS[@]}" \

--- a/examples/scripts/docker_run.sh
+++ b/examples/scripts/docker_run.sh
@@ -35,9 +35,8 @@ else
 fi
 
 ENV_FLAGS=()
-# Pass env vars by name only (docker reads the value from the host env) and
-# keep xtrace off while expanding them, so tokens never hit the trace, shell
-# history, or `ps` output.
+# Pass env vars by name only and keep xtrace off while expanding them,
+# so tokens never hit the trace, shell history, or `ps` output.
 { set +x; } 2>/dev/null
 for ENV_NAME in CUDA_VISIBLE_DEVICES FLASHINFER_WORKSPACE_BASE FLASHINFER_WORKSPACE_DIR HF_HOME HF_TOKEN HUGGING_FACE_HUB_TOKEN PYTORCH_CUDA_ALLOC_CONF; do
 	if [[ -n "${!ENV_NAME:-}" ]]; then

--- a/examples/scripts/docker_run.sh
+++ b/examples/scripts/docker_run.sh
@@ -45,7 +45,7 @@ for ENV_NAME in CUDA_VISIBLE_DEVICES FLASHINFER_WORKSPACE_BASE FLASHINFER_WORKSP
 done
 set -x
 
-docker run --runtime=nvidia --gpus "$DOCKER_GPUS" "${TTY_FLAGS[@]}" --rm --shm-size="$DOCKER_SHM_SIZE" --cap-add=SYS_ADMIN \
+docker run --gpus "$DOCKER_GPUS" "${TTY_FLAGS[@]}" --rm --shm-size="$DOCKER_SHM_SIZE" --cap-add=SYS_ADMIN \
 	"${ENV_FLAGS[@]}" \
 	-v $PROJECT_PATH:/molt -v  $HOME/.cache:/root/.cache -v  $HOME/.bash_history2:/root/.bash_history \
 	$IMAGE_NAME bash -lc "cd /molt && $CONTAINER_CMD"


### PR DESCRIPTION
Crashing without exposing the HF_TOKEN:

<img width="1275" height="298" alt="image" src="https://github.com/user-attachments/assets/268e10e7-0bfb-4237-ab20-5f42e39e2d2e" />

Also `--runtime=nvidia` causes the crash, should be safe to drop as it's redundant since Docker 19.03 released in July 2019

Closes #87 
Closes #88 