### PR TITLE
chore(deps): bump nemo-automodel e8a163b9 -> cfe722da; vLLM 0.27.1 ->…

### DIFF
--- a/dockerfile/Dockerfile
+++ b/dockerfile/Dockerfile
@@ -17,7 +17,7 @@
 #
 # Base: OFFICIAL Docker Hub pytorch/pytorch:2.13.0-cuda13.0-cudnn9-devel
 #   (torch 2.13.0 + CUDA 13.0 + cuDNN 9.20, python 3.12, Ubuntu 24.04).
-#   Chosen because torch 2.13.0+cu130 matches vLLM 0.27.x's hard torch==2.13.0 pin — NO torch
+#   Chosen because torch 2.13.0+cu130 matches vLLM 0.27/0.28's hard torch==2.13.0 pin — NO torch
 #   swap. The whole source stack (TE / flash-attn / mamba / DeepEP) is compiled against this
 #   torch, so the base torch version and vLLM must stay in lockstep.
 #
@@ -158,7 +158,7 @@ RUN apt-get update && apt-get install -y --allow-change-held-packages rdma-core 
     rm -rf /var/lib/apt/lists/* /opt/deepep.patch && cd / && rm -rf /opt/DeepEP
 # RDMA_CORE_HOME=/opt/rdma-core/build symlinks to the system (apt) rdma-core at runtime.
 
-# --- (e) vLLM 0.25.1 (cu130) ----------------------------------------------------
+# --- (e) vLLM 0.28.0 (cu130) ----------------------------------------------------
 # Pin the base cu130 torch trio via a constraints file so pip can never swap it; let pip
 # pull vLLM's cu13 kernel deps (flashinfer-cu13, nvidia-cutlass-dsl, etc.).
 # vllm[audio] (not bare vllm): the official Nemotron-Omni GA model carries a Parakeet
@@ -167,7 +167,7 @@ RUN apt-get update && apt-get install -y --allow-change-held-packages rdma-core 
 # vision-only RL and the encoder is frozen — but the weights must load. Torch-pinned so the
 # [audio] extra (librosa/soundfile; torchaudio already in base) can't swap the torch trio.
 # Baking it here removes the per-run, per-node rl_omni3 MOLT_INSTALL_AUDIO install.
-RUN python -m pip install -c /opt/torch-pin.txt "vllm[audio]==0.27.1"
+RUN python -m pip install -c /opt/torch-pin.txt "vllm[audio]==0.28.0"
 
 # --- VLM modeling-code runtime deps + molt requirements + fla -----------
 # requirements.txt minus what's already pinned/built above (torch trio, TE, flash-attn,
@@ -197,20 +197,23 @@ RUN python -m pip install --no-cache-dir "tilelang==0.1.11" "tile-kernels==1.0.0
 # is container-local, so every job would recompile the DSA kernels from scratch.
 ENV TILELANG_CACHE_DIR=/root/.cache/tilelang
 
-# vLLM 0.26 hard-pins nvidia-cutlass-dsl==4.6.0, whose cutlass.cute DSL dropped `ThrMma`. The
-# quack-kernels that dion pulls can lag that API and then AttributeError at import, taking
-# `import mamba_ssm` (mamba3 -> quack) down with it. Pin quack to the 4.6.0-compatible 0.6.1.
-# -c reuses the torch-trio pin from build start + cutlass 4.6.0 so this can't perturb the stack.
-RUN { cat /opt/torch-pin.txt; echo 'nvidia-cutlass-dsl==4.6.0'; } > /tmp/pin.txt && \
-    python -m pip install -c /tmp/pin.txt "quack-kernels==0.6.1" && rm -f /tmp/pin.txt
+# vLLM pins nvidia-cutlass-dsl (0.28.0 -> 4.6.2); the cutlass.cute DSL API moves between
+# releases, and the quack-kernels that dion pulls can lag it and then AttributeError at
+# import, taking `import mamba_ssm` (mamba3 -> quack) down with it. Pin quack to the
+# 4.6.2-compatible 0.6.4 (AutoModel's quack==0.6.1 metadata pin predates cutlass 4.6.2 —
+# pip warns about it, but 0.6.4 imports clean and passes the unit suite).
+# -c reuses the torch-trio pin from build start + cutlass 4.6.2 so this can't perturb the stack.
+RUN { cat /opt/torch-pin.txt; echo 'nvidia-cutlass-dsl==4.6.2'; } > /tmp/pin.txt && \
+    python -m pip install -c /tmp/pin.txt "quack-kernels==0.6.4" && rm -f /tmp/pin.txt
 
 # --- restore DeepEP's NVSHMEM ABI ----------------------------------------------
-# DeepEP (step c) built deep_ep_cpp.so against nvidia-nvshmem-cu13==3.6.5, but vLLM hard-pins
-# ==3.4.5, so its install above DOWNGRADED the wheel -> deep_ep_cpp.so then fails to load with
+# DeepEP (step c) built deep_ep_cpp.so against nvidia-nvshmem-cu13==3.6.5, but vLLM's dep set
+# can drag it back to ==3.4.5 (0.27.1 hard-pinned it; 0.28.0 keeps it only transitively) ->
+# deep_ep_cpp.so then fails to load with
 # `undefined symbol: nvshmem_selected_device_transport, version NVSHMEM`. Force nvshmem back to
 # 3.6.5 as the LAST pip action (a backward-compatible superset: it keeps 3.4.5's symbols for
-# vLLM while restoring the newer one DeepEP needs). --no-deps so pip does NOT re-drag vLLM's
-# ==3.4.5 pin, and re-create the unversioned .so symlink the DeepEP step made.
+# vLLM while restoring the newer one DeepEP needs). --no-deps so pip cannot re-drag the
+# older pin, and re-create the unversioned .so symlink the DeepEP step made.
 RUN python -m pip install --no-deps --force-reinstall nvidia-nvshmem-cu13==3.6.5 && \
     NVSHMEM_LIB_PATH=$(pip show nvidia-nvshmem-cu13 | awk '/^Location:/{print $2}')/nvidia/nvshmem/lib && \
     ln -sf ${NVSHMEM_LIB_PATH}/libnvshmem_host.so.3 ${NVSHMEM_LIB_PATH}/libnvshmem_host.so

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ einops
 grpcio>=1.74.0
 huggingface_hub>=1.0.0
 jsonlines
-nemo-automodel @ git+https://github.com/NVIDIA-NeMo/Automodel.git@e8a163b97ff979d7bf779e0509eda20ce1c3557d
+nemo-automodel @ git+https://github.com/NVIDIA-NeMo/Automodel.git@cfe722da8016f916276fb3c0b60c926dcabd6aee
 optree>=0.15.0
 packaging
 peft

--- a/setup.py
+++ b/setup.py
@@ -96,7 +96,7 @@ setup(
     long_description_content_type="text/markdown",
     install_requires=_fetch_requirements("requirements.txt"),
     extras_require={
-        "vllm": ["vllm==0.27.1"],
+        "vllm": ["vllm==0.28.0"],
         "vllm_latest": ["vllm>=0.24.0"],
         "flash-attn-2": ["flash-attn==2.8.3"],
     },


### PR DESCRIPTION
… 0.28.0

AutoModel: 92 commits of main (2026-08-12 -> 2026-08-28). Verified before bumping:

- API surface: all 18 nemo_automodel symbols molt imports are intact at the new commit with signatures matching molt's call sites (Checkpointer / CheckpointingConfig, ContextParallelSharder, RouterReplay / R3, mesh utils, Gate, scale_grads_and_clip_grad_norm, ModelRegistry, ...). R3 and CP sharding are untouched in the range; the sigmoid-router fp32 scoring fix is a no-op under molt's pinned gate_precision=float32. No molt code change.
- Dep floors unchanged (transformers==5.12.1, TE>=2.14.1, fla>=0.4.2, tilelang>=0.1.11). One new optional dep (nvidia-cudnn-frontend, cudnn attn backend) is lazy-imported and unreachable from molt's te/sdpa/fa2 paths.

vLLM 0.27.1 -> 0.28.0 (601 commits; still hard-pins torch==2.13.0, so the base image and the source-built TE/flash-attn/mamba/DeepEP stack are untouched). Verified:

- All 30 AsyncEngineArgs kwargs molt passes exist at 0.28.0 (incl. enable_return_routed_experts, logprobs_mode=processed_logprobs, gdn_prefill_backend, mamba_ssm_cache_dtype); AsyncLLM pause/resume, reset_prefix_cache, collective_rpc and the OpenAI-server mounting path are unchanged; worker_extension_cls plumbing and the router TITO wire format (routed_experts base64 .npy) are identical. Nothing molt uses was removed.
- vLLM 0.28.0 moves nvidia-cutlass-dsl 4.6.0 -> 4.6.2, so the Dockerfile quack-kernels pin goes 0.6.1 -> 0.6.4 (AutoModel's quack==0.6.1 metadata pin predates cutlass 4.6.2; 0.6.4 imports clean and passes the unit suite). The nvshmem 3.6.5 restore step for DeepEP stays as-is.

Runtime verification (interactive nodes; shipped 0.1.6 image patched in place with vllm==0.28.0, Automodel cfe722da via PYTHONPATH):

- Dockerfile import self-check + deep_ep (nvshmem ABI) import on GPU: OK.
- python -m compileall + full unit suite in the patched container: 218 passed.
- rl_qwen3_6_35b geo3k recipe, 2 nodes: all 4 vLLM 0.28 engines up with the R3 capturer active, no engine kwargs dropped, NCCL weight sync + broadcast OK; step-1 vllm_kl 1.1e-4 / 2.3e-4 across two runs, reward 0.875 / 0.92, peak actor mem 65.4 GB vs 67.5 GB on the unbumped control at identical settings (the step-2 OOM at recipe defaults reproduces on the current main stack too, i.e. pre-existing recipe tightness, not a regression).
- Multi-step vllm_kl A/B (OFFLOAD_OPTIMIZER=1, new stack vs 0.27.1 control) still running; results to follow on the PR before merge.