### PR TITLE
fix: guard EP activation checkpointing

### DIFF
--- a/examples/scripts/quick_start/rl_qwen3_6_35b.sh
+++ b/examples/scripts/quick_start/rl_qwen3_6_35b.sh
@@ -102,7 +102,7 @@ python3 -u -m molt.cli.train_rl_ray \
   --fsdp.tp_size 1 \
   --fsdp.ep_size 4 \
   --fsdp.cp_size 2 \
-  --actor.gradient_checkpoint full \
+  --actor.gradient_checkpoint none \
   --actor.freeze_visual_encoder \
   --actor.adam.lr 2e-6 \
   --actor.eps_clip_low_high 0.2 0.28 \

--- a/examples/scripts/quick_start/sft_qwen3_6_35b.sh
+++ b/examples/scripts/quick_start/sft_qwen3_6_35b.sh
@@ -75,7 +75,7 @@ torchrun --standalone --nproc_per_node="$GPUS_PER_NODE" -m molt.cli.train_sft \
   --fsdp.tp_size "$TP_SIZE" \
   --fsdp.ep_size "$EP_SIZE" \
   --fsdp.cp_size "$CP_SIZE" \
-  --model.gradient_checkpoint full \
+  --model.gradient_checkpoint none \
   --adam.lr "${LR:-1e-6}" \
   --model.aux_loss_coef "${MOE_AUX_LOSS_COEF:-0.001}" \
   --logger.wandb.project "${WANDB_PROJECT:-molt_quickstart_sft_qwen3_6}" \

--- a/examples/scripts/slurm/rl_distill_omni3_30b.sh
+++ b/examples/scripts/slurm/rl_distill_omni3_30b.sh
@@ -57,7 +57,7 @@ export REF_MODEL_PATH="${REF_MODEL_PATH:-}"
 export TP_SIZE="${TP_SIZE:-1}"        # AutoModel custom MoE asserts TP=1
 export EP_SIZE="${EP_SIZE:-8}"        # only model-state shard knob for this MoE
 export CP_SIZE="${CP_SIZE:-8}"        # shard sequence; CP8 leaves headroom for the colocated teacher
-export GRAD_CHECKPOINT="${GRAD_CHECKPOINT-full}"
+export GRAD_CHECKPOINT="${GRAD_CHECKPOINT-none}"
 export FSDP_ATTN_IMPLEMENTATION="${FSDP_ATTN_IMPLEMENTATION:-te}"
 
 # 16K by default (vs 32K for plain RL): the colocated teacher adds a full model's params to

--- a/examples/scripts/slurm/rl_glm5_2_753b.sh
+++ b/examples/scripts/slurm/rl_glm5_2_753b.sh
@@ -40,8 +40,8 @@ export MODEL_PATH="${MODEL_PATH:-/path/to/models/GLM-5.2}"
 # 256 experts / 256 = 1 expert/rank.
 export TP_SIZE="${TP_SIZE:-1}"
 export EP_SIZE="${EP_SIZE:-256}"
-# Activation checkpointing ON (safe under the hybridep MoE dispatcher; deterministic
-# recompute).
+# Activation checkpointing ON (safe because MOLT_MOE_DISPATCHER=torch below;
+# full AC is incompatible with hybridep/deepep under EP>1).
 export GRAD_CHECKPOINT="${GRAD_CHECKPOINT-full}"
 # CP=16 (DSA is THD-native: the model-owned sharder flattens [B,S] and contiguous-shards
 # from seq_lens). It also sets the DP width: dp = world 256 / cp16 = 16, and a rollout

--- a/examples/scripts/slurm/rl_omni3_30b.sh
+++ b/examples/scripts/slurm/rl_omni3_30b.sh
@@ -45,7 +45,7 @@ export MODEL_PATH="${MODEL_PATH:-/path/to/models/NVIDIA-Nemotron-3-Nano-Omni-30B
 export TP_SIZE="${TP_SIZE:-1}"        # AutoModel custom MoE asserts TP=1
 export EP_SIZE="${EP_SIZE:-8}"        # only model-state shard knob for this MoE
 export CP_SIZE="${CP_SIZE:-8}"        # CP8 fits 32K on the 2-node DP2 actor (omni3 SFT-validated); hybrid-SSM CP fix is in
-export GRAD_CHECKPOINT="${GRAD_CHECKPOINT-full}"   # all blocks activation-checkpointed
+export GRAD_CHECKPOINT="${GRAD_CHECKPOINT-none}"   # full AC incompatible with EP>1 HybridEP/DeepEP
 # Custom AutoModel models reject flash_attention_2 (it silently falls to sdpa);
 # TE is the intended fused-attention backend for the native path.
 export FSDP_ATTN_IMPLEMENTATION="${FSDP_ATTN_IMPLEMENTATION:-te}"

--- a/examples/scripts/slurm/rl_qwen3_6_35b.sh
+++ b/examples/scripts/slurm/rl_qwen3_6_35b.sh
@@ -40,11 +40,11 @@ export MOLT_PATH="$REPO_ROOT"
 export MODEL_PATH="${MODEL_PATH:-/path/to/models/Qwen3.6-35B-A3B}"
 export TP_SIZE="${TP_SIZE:-1}"
 export EP_SIZE="${EP_SIZE:-8}"
-# Activation checkpointing ON by default — safe under the deepep MoE dispatcher
-# (the actor.py code default), which makes the expert routing/recompute
-# deterministic. The legacy torch dispatcher could drift the recomputed MoE
-# tensors and raise `CheckpointError: Recomputed values ... different metadata`.
-export GRAD_CHECKPOINT="${GRAD_CHECKPOINT-full}"
+# Activation checkpointing OFF by default — full AC is incompatible with the
+# HybridEP/DeepEP MoE dispatcher under EP>1 (upstream AutoModel
+# recompute-shape mismatch → CheckpointError). Override GRAD_CHECKPOINT=full
+# only with MOLT_MOE_DISPATCHER=torch.
+export GRAD_CHECKPOINT="${GRAD_CHECKPOINT-none}"
 # CP=8 (te-native CP path). dp = world 16 / cp8 = 2, and train.batch_size >= dp
 # holds. CP shards the 32K sequence to 4096 tok/rank (non-GDN; GDN layers all-gather
 # the full sequence intra-node) — CP is for activation memory / long context; te

--- a/examples/scripts/slurm/sft_omni3_30b.sh
+++ b/examples/scripts/slurm/sft_omni3_30b.sh
@@ -70,10 +70,10 @@ MAX_SAMPLES="${MAX_SAMPLES:-8192}"
 TRAIN_BATCH_SIZE="${TRAIN_BATCH_SIZE:-8}"
 MICRO_BATCH_SIZE="${MICRO_BATCH_SIZE:-1}"
 
-# Omni3 native path: TE native cuDNN-fused attention. Grad-ckpt ON by default —
-# the deepep dispatcher makes the MoE recompute deterministic under AC.
+# Omni3 native path: TE native cuDNN-fused attention. Grad-ckpt OFF by default —
+# full AC is incompatible with EP>1 HybridEP/DeepEP dispatchers.
 FSDP_ATTN_IMPLEMENTATION="${FSDP_ATTN_IMPLEMENTATION:-te}"
-GRAD_CHECKPOINT="${GRAD_CHECKPOINT-full}"
+GRAD_CHECKPOINT="${GRAD_CHECKPOINT-none}"
 
 test -f "$CONTAINER_IMAGE"
 test -e "$SFT_DATASET"

--- a/examples/scripts/slurm/sft_qwen3_6_35b.sh
+++ b/examples/scripts/slurm/sft_qwen3_6_35b.sh
@@ -113,7 +113,7 @@ TRAIN_ARGS=(
   --fsdp.tp_size "$TP_SIZE"
   --fsdp.ep_size "$EP_SIZE"
   --fsdp.cp_size "$CP_SIZE"
-  --model.gradient_checkpoint full
+  --model.gradient_checkpoint none
   --adam.lr "${LR:-1e-6}"
   --model.aux_loss_coef "${MOE_AUX_LOSS_COEF:-0.001}"
   --logger.wandb.project "${WANDB_PROJECT:-molt_sft_qwen3_6}"

--- a/molt/cli/common_args.py
+++ b/molt/cli/common_args.py
@@ -20,7 +20,39 @@ adds a flag and the SFT launcher silently keeps a stale default — exactly the
 ``--adam.lr`` vs ``--actor.adam.lr`` default skew this module now pins down.
 """
 
+import os
 from datetime import datetime
+
+
+def validate_ep_gradient_checkpoint(ep_size: int, gradient_checkpoint) -> None:
+    """Reject ep_size>1 + full activation checkpointing under HybridEP/DeepEP.
+
+    The upstream AutoModel expert dispatch recomputes tensor shapes that
+    differ from the forward pass under these dispatchers, triggering
+    CheckpointError on the first backward.  Guard early so users see a
+    clear message instead of a cryptic shape mismatch.
+    """
+    if ep_size <= 1:
+        return
+    # Inline the "is this full AC?" check from resolve_ac_mode to avoid
+    # importing molt.models (which chains into heavy GPU deps).
+    if isinstance(gradient_checkpoint, str):
+        v = gradient_checkpoint.strip().lower()
+        is_full = v not in ("", "false", "none", "off", "0", "selective")
+    else:
+        is_full = bool(gradient_checkpoint)
+    if not is_full:
+        return
+    dispatcher = os.environ.get("MOLT_MOE_DISPATCHER", "hybridep").lower()
+    if dispatcher not in ("hybridep", "deepep"):
+        return
+    raise ValueError(
+        f"Full activation checkpointing is incompatible with expert-parallel "
+        f"dispatch ({dispatcher}) when ep_size={ep_size}. "
+        f"Set --model.gradient_checkpoint none (SFT) or "
+        f"--actor.gradient_checkpoint none (RL), or override "
+        f"MOLT_MOE_DISPATCHER=torch."
+    )
 
 
 def add_fsdp_args(parser) -> None:

--- a/molt/cli/train_rl_ray.py
+++ b/molt/cli/train_rl_ray.py
@@ -284,6 +284,7 @@ if __name__ == "__main__":
         add_logger_args,
         add_optimizer_args,
         resolve_ckpt_retention,
+        validate_ep_gradient_checkpoint,
     )
 
     # ====================== Shared blocks (same surface as train_sft) ======================
@@ -1001,6 +1002,8 @@ if __name__ == "__main__":
     # --- Parallelism / FSDP ---
     if args.fsdp.pp_size > 1:
         raise NotImplementedError("Molt trainers are not pipeline-parallel aware yet; set --fsdp.pp_size 1")
+
+    validate_ep_gradient_checkpoint(args.fsdp.ep_size, args.actor.gradient_checkpoint)
 
     if args.train.routing_replay and args.train.partial_rollout_enable:
         # vLLM frees a request's captured routing on preemption, and partial

--- a/molt/cli/train_sft.py
+++ b/molt/cli/train_sft.py
@@ -153,6 +153,7 @@ if __name__ == "__main__":
         add_logger_args,
         add_optimizer_args,
         resolve_ckpt_retention,
+        validate_ep_gradient_checkpoint,
     )
 
     # ====================== Shared blocks (same surface as train_rl_ray) ======================
@@ -261,6 +262,8 @@ if __name__ == "__main__":
     # --- Parallelism / FSDP ---
     if args.fsdp.pp_size > 1:
         raise NotImplementedError("Molt trainers are not pipeline-parallel aware yet; set --fsdp.pp_size 1")
+
+    validate_ep_gradient_checkpoint(args.fsdp.ep_size, args.model.gradient_checkpoint)
 
     if args.data.image_key and args.fsdp.packing_samples:
         raise ValueError(

--- a/tests/unit/test_ep_ac_validation.py
+++ b/tests/unit/test_ep_ac_validation.py
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from molt.cli.common_args import validate_ep_gradient_checkpoint
+
+
+def test_ep1_full_allowed():
+    validate_ep_gradient_checkpoint(1, "full")
+
+
+def test_ep_gt1_full_hybridep_rejected(monkeypatch):
+    monkeypatch.setenv("MOLT_MOE_DISPATCHER", "hybridep")
+    with pytest.raises(ValueError, match="incompatible with expert-parallel"):
+        validate_ep_gradient_checkpoint(4, "full")
+
+
+def test_ep_gt1_full_deepep_rejected(monkeypatch):
+    monkeypatch.setenv("MOLT_MOE_DISPATCHER", "deepep")
+    with pytest.raises(ValueError, match="incompatible with expert-parallel"):
+        validate_ep_gradient_checkpoint(8, "full")
+
+
+def test_ep_gt1_none_allowed(monkeypatch):
+    monkeypatch.setenv("MOLT_MOE_DISPATCHER", "hybridep")
+    validate_ep_gradient_checkpoint(4, "none")
+
+
+def test_ep_gt1_full_torch_allowed(monkeypatch):
+    monkeypatch.setenv("MOLT_MOE_DISPATCHER", "torch")
+    validate_ep_gradient_checkpoint(8, "full")
+
+
+def test_ep_gt1_full_default_dispatcher_rejected(monkeypatch):
+    monkeypatch.delenv("MOLT_MOE_DISPATCHER", raising=False)
+    with pytest.raises(ValueError, match="incompatible with expert-parallel"):
+        validate_ep_gradient_checkpoint(2, "full")
+
+
+def test_dense_model_full_allowed(monkeypatch):
+    monkeypatch.delenv("MOLT_MOE_DISPATCHER", raising=False)
+    validate_ep_gradient_checkpoint(1, "full")
+
+
+def test_ep_gt1_selective_allowed(monkeypatch):
+    monkeypatch.setenv("MOLT_MOE_DISPATCHER", "hybridep")
+    validate_ep_gradient_checkpoint(4, "selective")
+
+
+def test_ep_gt1_bool_true_rejected(monkeypatch):
+    monkeypatch.setenv("MOLT_MOE_DISPATCHER", "hybridep")
+    with pytest.raises(ValueError, match="incompatible with expert-parallel"):
+        validate_ep_gradient_checkpoint(4, True)
+
+
+def test_ep_gt1_bool_false_allowed(monkeypatch):
+    monkeypatch.setenv("MOLT_MOE_DISPATCHER", "hybridep")
+    validate_ep_gradient_checkpoint(4, False)


### PR DESCRIPTION
## Summary

Add early validation for EP training configurations that combine `ep_size > 1` with full activation checkpointing under HybridEP/DeepEP dispatch. This fails fast with a clear error instead of surfacing a backward-time checkpoint shape mismatch.

Update affected SFT/RL example scripts to default gradient checkpointing to `none` for EP configurations, while documenting that full checkpointing can still be used with `MOLT_MOE_DISPATCHER=torch`.

## Test Plan

- `python -m py_compile molt\cli\common_args.py molt\cli\train_rl_ray.py molt\cli\train_sft.py tests\unit\test_ep_ac_validation.py`
- Not run; reason: local environment is missing `pytest`.