### PR TITLE
chore(deps): bump nemo-automodel f40e0161 -> 67393519

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ einops
 grpcio>=1.74.0
 huggingface_hub>=1.0.0
 jsonlines
-nemo-automodel @ git+https://github.com/NVIDIA-NeMo/Automodel.git@f40e0161901f291899dccbfde6c78335016af769
+nemo-automodel @ git+https://github.com/NVIDIA-NeMo/Automodel.git@6739351966b6d73cec2e9e6179f9d107a329b4f0
 optree>=0.15.0
 packaging
 peft


### PR DESCRIPTION
## Summary
- bump nemo-automodel f40e0161 -> 67393519 (latest main, 29 commits): AutoModel 0.7.0, transformers 5.15.1 pin, DeepSeek V4 Flash Vision, GLM-5.3 cuDNN training support, Kimi-K3 routing/PP/MFU correctness fixes + memory/throughput perf, FSDP full-layer activation checkpointing for KV-shared models, TP KD gradient over-reduction fix

## Validation
- image rebuilt with the new pin (hijkzzz/molt:0.1.7): build-time import self-check + version asserts (torch 2.13.0+cu130, vLLM 0.28.0, quack 0.6.4, cutlass-dsl 4.6.2, nvshmem 3.6.5, tilelang 0.1.11) all pass
- full unit suite inside the image: 218 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)