### PR TITLE
chore(deps): bump vLLM 0.28.0 -> 0.29.0, nemo-automodel 67393519 -> f…

### DIFF
--- a/dockerfile/Dockerfile
+++ b/dockerfile/Dockerfile
@@ -17,7 +17,7 @@
 #
 # Base: OFFICIAL Docker Hub pytorch/pytorch:2.13.0-cuda13.0-cudnn9-devel
 #   (torch 2.13.0 + CUDA 13.0 + cuDNN 9.20, python 3.12, Ubuntu 24.04).
-#   Chosen because torch 2.13.0+cu130 matches vLLM 0.27/0.28's hard torch==2.13.0 pin — NO torch
+#   Chosen because torch 2.13.0+cu130 matches vLLM 0.27–0.29's hard torch==2.13.0 pin — NO torch
 #   swap. The whole source stack (TE / flash-attn / mamba / DeepEP) is compiled against this
 #   torch, so the base torch version and vLLM must stay in lockstep.
 #
@@ -158,7 +158,7 @@ RUN apt-get update && apt-get install -y --allow-change-held-packages rdma-core 
     rm -rf /var/lib/apt/lists/* /opt/deepep.patch && cd / && rm -rf /opt/DeepEP
 # RDMA_CORE_HOME=/opt/rdma-core/build symlinks to the system (apt) rdma-core at runtime.
 
-# --- (e) vLLM 0.28.0 (cu130) ----------------------------------------------------
+# --- (e) vLLM 0.29.0 (cu130) ----------------------------------------------------
 # Pin the base cu130 torch trio via a constraints file so pip can never swap it; let pip
 # pull vLLM's cu13 kernel deps (flashinfer-cu13, nvidia-cutlass-dsl, etc.).
 # vllm[audio] (not bare vllm): the official Nemotron-Omni GA model carries a Parakeet
@@ -167,7 +167,7 @@ RUN apt-get update && apt-get install -y --allow-change-held-packages rdma-core 
 # vision-only RL and the encoder is frozen — but the weights must load. Torch-pinned so the
 # [audio] extra (librosa/soundfile; torchaudio already in base) can't swap the torch trio.
 # Baking it here removes the per-run, per-node rl_omni3 MOLT_INSTALL_AUDIO install.
-RUN python -m pip install -c /opt/torch-pin.txt "vllm[audio]==0.28.0"
+RUN python -m pip install -c /opt/torch-pin.txt "vllm[audio]==0.29.0"
 
 # --- VLM modeling-code runtime deps + molt requirements + fla -----------
 # requirements.txt minus what's already pinned/built above (torch trio, TE, flash-attn,
@@ -189,9 +189,15 @@ RUN if [ "$INSTALL_TEST_DEPS" = "1" ]; then python -m pip install coverage pytes
     python -c "import importlib.util as u; assert u.find_spec('fla.ops.cp') and u.find_spec('fla.modules.convolution') and u.find_spec('fla.ops.gated_delta_rule'), 'fla CP ops missing'" && \
     rm -f /tmp/requirements.txt /tmp/req.filtered.txt
 
+# transformers 5.17.0 on top of AutoModel's exact ==5.15.1 metadata pin (pip warns; imports
+# clean, unit suite passes); vLLM 0.29.0 only needs >=5.10.4. Kept out of requirements.txt on
+# purpose — a second hard pin in the same resolve would be ResolutionImpossible — and it must
+# come AFTER the requirements install above, which otherwise settles on AutoModel's pin.
+RUN python -m pip install -c /opt/torch-pin.txt "transformers==5.17.0"
+
 # DSA sparse attention (backend.attn="tilelang"): AutoModel's `cuda` extra. The pin is
 # load-bearing — 0.1.9 compiles the kernels but its backward NaNs once an index block mixes
-# real keys with the -1 sentinel, which causal top-k always produces. vLLM 0.28.0 hard-pins
+# real keys with the -1 sentinel, which causal top-k always produces. vLLM 0.28+ hard-pins
 # tilelang==0.1.12; this step deliberately downgrades it back (pip warns) — 0.1.12 is
 # unvalidated for the DSA backward, so keep this step AFTER the vLLM install.
 RUN python -m pip install --no-cache-dir "tilelang==0.1.11" "tile-kernels==1.0.0" "apache-tvm-ffi<=0.1.11"
@@ -199,18 +205,17 @@ RUN python -m pip install --no-cache-dir "tilelang==0.1.11" "tile-kernels==1.0.0
 # is container-local, so every job would recompile the DSA kernels from scratch.
 ENV TILELANG_CACHE_DIR=/root/.cache/tilelang
 
-# vLLM pins nvidia-cutlass-dsl (0.28.0 -> 4.6.2); the cutlass.cute DSL API moves between
+# vLLM pins nvidia-cutlass-dsl (0.28/0.29 -> 4.6.2); the cutlass.cute DSL API moves between
 # releases, and the quack-kernels that dion pulls can lag it and then AttributeError at
 # import, taking `import mamba_ssm` (mamba3 -> quack) down with it. Pin quack to the
-# 4.6.2-compatible 0.6.4 (AutoModel's quack==0.6.1 metadata pin predates cutlass 4.6.2 —
-# pip warns about it, but 0.6.4 imports clean and passes the unit suite).
+# 4.6.2-compatible 0.6.4 (AutoModel pins the same version since 67393519).
 # -c reuses the torch-trio pin from build start + cutlass 4.6.2 so this can't perturb the stack.
 RUN { cat /opt/torch-pin.txt; echo 'nvidia-cutlass-dsl==4.6.2'; } > /tmp/pin.txt && \
     python -m pip install -c /tmp/pin.txt "quack-kernels==0.6.4" && rm -f /tmp/pin.txt
 
 # --- restore DeepEP's NVSHMEM ABI ----------------------------------------------
 # DeepEP (step c) built deep_ep_cpp.so against nvidia-nvshmem-cu13==3.6.5, but vLLM's dep set
-# can drag it back to ==3.4.5 (0.27.1 hard-pinned it; 0.28.0 keeps it only transitively) ->
+# can drag it back to ==3.4.5 (0.27.1 hard-pinned it; 0.28+ keeps it only transitively) ->
 # deep_ep_cpp.so then fails to load with
 # `undefined symbol: nvshmem_selected_device_transport, version NVSHMEM`. Force nvshmem back to
 # 3.6.5 as the LAST pip action (a backward-compatible superset: it keeps 3.4.5's symbols for

--- a/molt/trainer/vllm/vllm_engine.py
+++ b/molt/trainer/vllm/vllm_engine.py
@@ -133,8 +133,11 @@ class RolloutRayActor:
         """
         import uvicorn
         from vllm.entrypoints.openai import api_server as _api
-        from vllm.entrypoints.openai.cli_args import make_arg_parser
 
+        try:  # vLLM 0.29 moved the serve CLI into entrypoints.launchers (openai.cli_args is gone)
+            from vllm.entrypoints.launchers.cli_args import make_arg_parser
+        except ImportError:
+            from vllm.entrypoints.openai.cli_args import make_arg_parser
         try:  # location moved across vLLM versions (utils.argparse_utils -> entrypoints.utils)
             from vllm.utils.argparse_utils import FlexibleArgumentParser
         except ImportError:

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ einops
 grpcio>=1.74.0
 huggingface_hub>=1.0.0
 jsonlines
-nemo-automodel @ git+https://github.com/NVIDIA-NeMo/Automodel.git@6739351966b6d73cec2e9e6179f9d107a329b4f0
+nemo-automodel @ git+https://github.com/NVIDIA-NeMo/Automodel.git@f530354246e951a05f8b856f7ce5a21ad7013ed8
 optree>=0.15.0
 packaging
 peft

--- a/setup.py
+++ b/setup.py
@@ -96,7 +96,7 @@ setup(
     long_description_content_type="text/markdown",
     install_requires=_fetch_requirements("requirements.txt"),
     extras_require={
-        "vllm": ["vllm==0.28.0"],
+        "vllm": ["vllm==0.29.0"],
         "vllm_latest": ["vllm>=0.24.0"],
         "flash-attn-2": ["flash-attn==2.8.3"],
     },


### PR DESCRIPTION
…5303542, transformers 5.17.0

vLLM 0.29.0 keeps the torch==2.13.0 pin (no source-stack rebuild) but moved the serve CLI into entrypoints.launchers and dropped entrypoints.openai.cli_args, so serve_openai() now imports make_arg_parser from the new location with a fallback to the old one; build_app/init_app_state keep the signatures molt already calls. transformers 5.17.0 is installed as a separate Dockerfile step on top of AutoModel's exact ==5.15.1 pin (a second pin in requirements.txt would be ResolutionImpossible).