### PR TITLE
chore(docker): drop the explicit transformers pin, follow AutoModel

### DIFF
--- a/dockerfile/Dockerfile
+++ b/dockerfile/Dockerfile
@@ -177,6 +177,8 @@ RUN python -m pip install -c /opt/torch-pin.txt "vllm[audio]==0.29.0"
 # NOTE: nemo-automodel is intentionally NOT filtered out — it installs from the requirements.txt
 # git pin here, baking AutoModel into the image (self-contained for Docker Hub). The runtime
 # PYTHONPATH sibling-checkout override (above) takes precedence over this baked copy.
+# transformers is deliberately NOT pinned anywhere in this repo: AutoModel's exact pin wins here
+# (vLLM only sets a floor), so its validated transformers version travels with the AutoModel bump.
 ARG INSTALL_TEST_DEPS=0
 COPY requirements.txt /tmp/requirements.txt
 RUN if [ "$INSTALL_TEST_DEPS" = "1" ]; then python -m pip install coverage pytest; fi && \
@@ -188,12 +190,6 @@ RUN if [ "$INSTALL_TEST_DEPS" = "1" ]; then python -m pip install coverage pytes
     python -m pip install --no-cache-dir --no-deps "flash-linear-attention==0.4.2" "fla-core==0.4.2" && \
     python -c "import importlib.util as u; assert u.find_spec('fla.ops.cp') and u.find_spec('fla.modules.convolution') and u.find_spec('fla.ops.gated_delta_rule'), 'fla CP ops missing'" && \
     rm -f /tmp/requirements.txt /tmp/req.filtered.txt
-
-# transformers 5.17.0 on top of AutoModel's exact ==5.15.1 metadata pin (pip warns; imports
-# clean, unit suite passes); vLLM 0.29.0 only needs >=5.10.4. Kept out of requirements.txt on
-# purpose — a second hard pin in the same resolve would be ResolutionImpossible — and it must
-# come AFTER the requirements install above, which otherwise settles on AutoModel's pin.
-RUN python -m pip install -c /opt/torch-pin.txt "transformers==5.17.0"
 
 # DSA sparse attention (backend.attn="tilelang"): AutoModel's `cuda` extra. The pin is
 # load-bearing — 0.1.9 compiles the kernels but its backward NaNs once an index block mixes


### PR DESCRIPTION
## Summary
- remove the Dockerfile step that forced transformers==5.17.0 over nemo-automodel exact ==5.15.1 pin. AutoModel pins transformers exactly and vLLM 0.29.0 only sets a floor (>=5.10.4), so the requirements install already settles on the validated version; the override only created a metadata conflict. transformers is now deliberately not pinned anywhere in this repo (note added at the requirements step).
- nemo-automodel stays at f5303542.

## Validation (hijkzzz/molt:0.1.8 rebuilt with transformers 5.15.1)
- build-time import self-check + version asserts (torch 2.13.0+cu130, vLLM 0.29.0, transformers 5.15.1, flashinfer 0.6.18, quack 0.6.4, cutlass-dsl 4.6.2, nvshmem 3.6.5, tilelang 0.1.11, automodel 0.7.0+f5303542)
- unit suite inside the image: 218 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)