### PR TITLE
feat(rollout): dispatch rollouts one per runner call, re-join per group

### DIFF
--- a/molt/cli/train_rl_ray.py
+++ b/molt/cli/train_rl_ray.py
@@ -719,7 +719,8 @@ if __name__ == "__main__":
         "--rollout.num_runners",
         type=int,
         default=2,
-        help="Router path: number of runner-pool actors (rollouts + in-process reward grading)",
+        help="Router path: number of runner-pool actors (rollouts + in-process reward grading). Rollouts "
+        "are dispatched one per call, so up to vllm_generate_batch_size * n_samples_per_prompt runners stay busy.",
     )
     parser.add_argument(
         "--rollout.vllm_generate_batch_size", type=int, default=None, help="Batch size for vLLM generating samples"

--- a/molt/trainer/rollout/router.py
+++ b/molt/trainer/rollout/router.py
@@ -304,7 +304,7 @@ class AgentRunnerActor:
     Loads the agent runner + tokenizer, holds one aiohttp session to the router + a
     ``RouterGenerateClient`` over it, and runs N rollouts of a prompt concurrently. Grading
     and VLM image processing run in-process (GIL-bound), so a fleet of these actors
-    (``--rollout.num_runners``) parallelizes that work; the trainer round-robins prompts
+    (``--rollout.num_runners``) parallelizes that work; the trainer round-robins rollouts
     across them (no pool wrapper — just a list + an index)."""
 
     def __init__(self, agent_path, router_url, *, model_path=None, model_name="policy"):
@@ -339,8 +339,13 @@ class AgentRunnerActor:
     async def ready(self):
         return True
 
-    async def run_group(self, prompt, label, images, sampling_params, max_length, n_samples, tools=None):
+    async def run_group(
+        self, prompt, label, images, sampling_params, max_length, n_samples, tools=None, group_id=None
+    ):
         """N rollouts of one prompt (unchanged runner) -> per step-sample ``(experience, drop_reason)``.
+
+        The trainer dispatches one rollout per call and passes the prompt's ``group_id`` so the
+        rollouts it spreads over several runners still form one group (see _gather_group).
 
         Each usable trajectory is built into a train-ready Experience HERE, on the producing runner,
         then `offload`ed: its heavy tensors (images / token ids / rollout routing) stay in THIS
@@ -350,7 +355,7 @@ class AgentRunnerActor:
         rollout is dropped, never sinks the group."""
         from molt.trainer.rollout.samples_generator import SamplesGenerator
 
-        group_id = uuid4().hex
+        group_id = group_id or uuid4().hex
         tasks = [
             self._runner.execute(
                 prompt=prompt,

--- a/molt/trainer/rollout/samples_generator.py
+++ b/molt/trainer/rollout/samples_generator.py
@@ -20,6 +20,7 @@ import copy
 import os
 from collections import defaultdict
 from typing import Dict, List, Optional, Tuple
+from uuid import uuid4
 
 import numpy as np
 import ray
@@ -81,6 +82,12 @@ def _collect_prompt_batch(dataloader_iter, num_prompts: int):
     return prompts, labels, images, tools, exhausted
 
 
+@ray.remote(num_cpus=0)
+def _gather_group(*parts):
+    """Re-join one prompt group's per-rollout results (runs once all of them finished)."""
+    return [item for part in parts for item in part]
+
+
 def _sample_group_key(sample) -> int | str:
     """Stable prompt-group key when rollout samples carry grouping metadata."""
     sample_group_ids = getattr(sample, "group_ids", None)
@@ -102,7 +109,7 @@ class SamplesGenerator:
         self.args = strategy.args
 
         self.tokenizer = tokenizer
-        # Runner actors driving rollouts through the vllm-router; prompts are round-robined
+        # Runner actors driving rollouts through the vllm-router; rollouts are round-robined
         # across them (self._rr) — no pool wrapper, just a list + an index.
         self.agent_runners = agent_runners
         self._rr = 0
@@ -446,9 +453,11 @@ class SamplesGenerator:
     def _dispatch_to_agent_runners(
         self, prompts: List[str], labels: List[str], *, images: List = None, tools: List = None, **generate_kwargs
     ) -> List:
-        """Round-robin each prompt group onto the runner actors; each ``run_group`` returns a
-        Ray ref of that group's Trajectories, consumed by the streaming loop / filtering /
-        experience maker exactly as before."""
+        """Round-robin each ROLLOUT onto the runner actors and re-join a prompt's rollouts into
+        one ref per group, consumed by the streaming loop / filtering / experience maker exactly
+        as before. Per-rollout (not per-group) dispatch: a runner's event loop is shared by all its
+        in-flight rollouts (grading, image processing and blocking tool calls run in-process), so
+        a group's N rollouts land on N runners instead of one."""
         sampling_params = SamplingParams(
             temperature=generate_kwargs.get("temperature", 1.0),
             top_p=generate_kwargs.get("top_p", 1.0),
@@ -467,11 +476,17 @@ class SamplesGenerator:
 
         refs = []
         for prompt, label, img, tool in zip(prompts, labels, images, tools):
-            actor = self.agent_runners[self._rr % len(self.agent_runners)]
-            self._rr += 1
-            refs.append(
-                actor.run_group.remote(prompt, label, img, sampling_params, truncate_length, n_samples, tools=tool)
-            )
+            group_id = uuid4().hex
+            parts = []
+            for _ in range(n_samples):
+                actor = self.agent_runners[self._rr % len(self.agent_runners)]
+                self._rr += 1
+                parts.append(
+                    actor.run_group.remote(
+                        prompt, label, img, sampling_params, truncate_length, 1, tools=tool, group_id=group_id
+                    )
+                )
+            refs.append(_gather_group.remote(*parts))
         return refs
 
     @staticmethod

--- a/tests/unit/test_samples_generator.py
+++ b/tests/unit/test_samples_generator.py
@@ -482,3 +482,33 @@ def test_warm_resume_state_dict_noop_when_disabled(tmp_path):
     gen.args = SimpleNamespace(ckpt=SimpleNamespace(warm_resume_rollouts=False, path=str(tmp_path / "ckpt")))
     gen._finished_samples = [SimpleNamespace(group_ids=["g0"], heavy_ref=None)]
     assert gen.state_dict() == {}
+
+
+def test_dispatch_spreads_each_groups_rollouts_over_runners_and_rejoins_them(monkeypatch):
+    generator = object.__new__(SamplesGenerator)
+    generator.args = SimpleNamespace(
+        rollout=SimpleNamespace(n_samples_per_prompt=4),
+        algo=SimpleNamespace(advantage=SimpleNamespace(is_correction_level="off")),
+    )
+    generator._rr = 0
+    calls = []
+
+    def runner(name):
+        def remote(prompt, label, img, sampling_params, max_length, n_samples, tools=None, group_id=None):
+            calls.append((prompt, n_samples, group_id))
+            return f"{name}:{prompt}"
+
+        return SimpleNamespace(run_group=SimpleNamespace(remote=remote))
+
+    generator.agent_runners = [runner("r0"), runner("r1")]
+    monkeypatch.setattr(samples_generator, "_gather_group", SimpleNamespace(remote=lambda *parts: list(parts)))
+
+    refs = generator._dispatch_to_agent_runners(["p0", "p1"], ["l0", "l1"])
+
+    # One re-joined ref per prompt group; its n_samples rollouts were dispatched one per call,
+    # round-robined across the runners...
+    assert refs == [["r0:p0", "r1:p0", "r0:p0", "r1:p0"], ["r0:p1", "r1:p1", "r0:p1", "r1:p1"]]
+    assert all(n_samples == 1 for _, n_samples, _ in calls)
+    # ...and all of a prompt's rollouts share one group_id that differs across prompts.
+    group_ids = {prompt: {gid for p, _, gid in calls if p == prompt} for prompt in ("p0", "p1")}
+    assert len(group_ids["p0"]) == 1 and len(group_ids["p1"]) == 1 and group_ids["p0"] != group_ids["p1"]


### PR DESCRIPTION
A runner actor's event loop is shared by every rollout in flight on it — grading, VLM image processing and the geo3k python tool's blocking subprocess all run in-process — yet a prompt group's N rollouts were all handed to ONE runner, so --rollout.num_runners could never spread a group and a blocking tool call stalled its 7 siblings. Dispatch each rollout as its own run_group(n_samples=1, group_id=...) call, round-robined across the runners, and re-join the group's parts with a num_cpus=0 Ray task so the streaming loop, DAPO filter, eval path and metrics still see exactly one ref per prompt group. Up to vllm_generate_batch_size * n_samples_per_prompt runners now stay busy (64 for the GRPO 8x8 recipes).