### PR TITLE
fix(rollout): require complete groups for group estimators

### DIFF
--- a/molt/trainer/rollout/samples_generator.py
+++ b/molt/trainer/rollout/samples_generator.py
@@ -29,6 +29,7 @@ from tqdm import tqdm
 from vllm import SamplingParams
 
 from molt.agents.base import _first_scalar as _to_scalar  # dedupe: same tensor/list/scalar normalizer
+from molt.trainer.algorithm.advantage import GROUP_ADVANTAGE_ESTIMATORS
 from molt.trainer.algorithm.experience import Experience, get_model_parallel_size
 from molt.utils.logging_utils import init_logger
 
@@ -259,7 +260,12 @@ class SamplesGenerator:
                 # Dropped groups (filtered or all-unusable) come back empty; their
                 # slot is refilled with a fresh prompt on the next iteration.
                 group_samples = self._filter_group(
-                    finished_rollout, dynamic_filtering, drop_counts, score_stats=score_stats, **generate_kwargs
+                    finished_rollout,
+                    dynamic_filtering,
+                    drop_counts,
+                    require_complete_group=self.args.algo.advantage.estimator in GROUP_ADVANTAGE_ESTIMATORS,
+                    score_stats=score_stats,
+                    **generate_kwargs,
                 )
                 if group_samples:
                     self._finished_samples.extend(group_samples)
@@ -336,6 +342,7 @@ class SamplesGenerator:
         finished_rollout,
         dynamic_filtering: bool,
         drop_counts: Dict[str, int],
+        require_complete_group: bool = False,
         score_stats: Dict[str, float] | None = None,
         **generate_kwargs,
     ) -> List[Experience]:
@@ -344,7 +351,7 @@ class SamplesGenerator:
 
         The single place the keep/drop policy lives, applying both filters:
         per-response (unusable trajectories dropped by ``_process_response_into_experience``)
-        and the group-level DAPO dynamic-reward filter. Returns ``[]`` when the
+        and the group-level completeness / DAPO reward filters. Returns ``[]`` when the
         whole group is dropped. Both the streaming (``generate_samples``) and
         batch/eval (``_generate_batch``) paths call it, so the per-group filter loop
         is never reimplemented.
@@ -359,7 +366,7 @@ class SamplesGenerator:
             elif drop_reason is not None:
                 drop_counts[drop_reason] += 1
 
-        if dynamic_filtering and group_samples:
+        if (dynamic_filtering or require_complete_group) and group_samples:
             # Compaction can emit several step-samples with the same terminal score. Keep one
             # representative per rollout for filtering; all segments still enter training below.
             rollout_samples = {
@@ -368,7 +375,7 @@ class SamplesGenerator:
             # Pre-filter score stats (the model's TRUE judge pass rate over scored rollouts, BEFORE
             # DAPO drops uniform groups). Accumulate here, before any keep/drop decision, so the
             # logged mean reflects all-pass + all-fail + mixed (not just the kept mixed groups).
-            if score_stats is not None:
+            if dynamic_filtering and score_stats is not None:
                 scored = [s.scores[0].item() for s in rollout_samples if s.scores is not None]
                 if scored:
                     min_score, max_score = self.args.algo.dynamic_filtering_range
@@ -378,18 +385,13 @@ class SamplesGenerator:
                     score_stats["groups"] += 1.0
                     score_stats["all_pass"] += float(gmean >= max_score)
                     score_stats["all_fail"] += float(gmean <= min_score)
-            # Require COMPLETE groups: a group that lost a response to a per-response drop
-            # (vlm_truncation / no_action_tokens / logprob_misalign / ...) has < n_samples
-            # usable samples, which would pull the accepted count off train_batch_size and make
-            # it indivisible by the DP-rank count -> per-sample forward microbatches split unevenly
-            # -> NCCL collective desync/hang. Drop+backfill the whole group so each accepted group
-            # contributes exactly n_samples (batch stays a clean groups_per_batch * n_samples).
+            # Group estimators need all N rollout rewards for their intended baseline. Dynamic
+            # filtering also needs complete groups to preserve batch divisibility across DP ranks.
             n_samples = generate_kwargs.get("n_samples_per_prompt", self.args.rollout.n_samples_per_prompt)
-            n_rollouts = len(rollout_samples)
-            if n_rollouts < n_samples:
+            if len(rollout_samples) < n_samples:
                 drop_counts["incomplete_group"] += len(group_samples)
                 return []
-            if not self._passes_dynamic_filter(rollout_samples):
+            if dynamic_filtering and not self._passes_dynamic_filter(rollout_samples):
                 drop_counts["dynamic_filter"] += len(group_samples)
                 return []
         return group_samples

--- a/tests/unit/test_samples_generator.py
+++ b/tests/unit/test_samples_generator.py
@@ -97,7 +97,7 @@ def test_generate_samples_returns_batch_as_rollouts_finish_and_keeps_pool_satura
     generator = object.__new__(SamplesGenerator)
     generator.args = SimpleNamespace(
         rollout=SimpleNamespace(batch_size=3, n_samples_per_prompt=1, vllm_generate_batch_size=5),
-        algo=SimpleNamespace(dynamic_filtering_enable=False),
+        algo=SimpleNamespace(dynamic_filtering_enable=False, advantage=SimpleNamespace(estimator="reinforce")),
         ckpt=SimpleNamespace(warm_resume_rollouts=False),
         actor=SimpleNamespace(num_nodes=1, num_gpus_per_node=1),
         fsdp=SimpleNamespace(cp_size=1, tp_size=1),
@@ -119,11 +119,53 @@ def test_generate_samples_returns_batch_as_rollouts_finish_and_keeps_pool_satura
     assert exhausted is False
 
 
+def test_generate_samples_drops_incomplete_group_for_group_estimator(monkeypatch):
+    generator = object.__new__(SamplesGenerator)
+    generator.args = SimpleNamespace(
+        rollout=SimpleNamespace(batch_size=1, n_samples_per_prompt=2, vllm_generate_batch_size=1),
+        algo=SimpleNamespace(
+            dynamic_filtering_enable=False, advantage=SimpleNamespace(estimator="reinforce_baseline")
+        ),
+        ckpt=SimpleNamespace(warm_resume_rollouts=False),
+        actor=SimpleNamespace(num_nodes=1, num_gpus_per_node=1),
+        fsdp=SimpleNamespace(cp_size=1, tp_size=1),
+    )
+    generator.prompts_dataloader = _prompt_loader(1)
+    _wire_fake_vllm(generator, monkeypatch, _sample)
+
+    samples, rollout_metrics, _, exhausted = generator.generate_samples()
+
+    assert samples == []
+    assert rollout_metrics == {
+        "rollout/dropped/incomplete_group": 1.0,
+        "rollout/dropped/total": 1.0,
+    }
+    assert exhausted is True
+
+
+def test_generate_samples_keeps_incomplete_group_for_per_sample_estimator(monkeypatch):
+    generator = object.__new__(SamplesGenerator)
+    generator.args = SimpleNamespace(
+        rollout=SimpleNamespace(batch_size=1, n_samples_per_prompt=2, vllm_generate_batch_size=1),
+        algo=SimpleNamespace(dynamic_filtering_enable=False, advantage=SimpleNamespace(estimator="reinforce")),
+        ckpt=SimpleNamespace(warm_resume_rollouts=False),
+        actor=SimpleNamespace(num_nodes=1, num_gpus_per_node=1),
+        fsdp=SimpleNamespace(cp_size=1, tp_size=1),
+    )
+    generator.prompts_dataloader = _prompt_loader(1)
+    _wire_fake_vllm(generator, monkeypatch, _sample)
+
+    samples, rollout_metrics, _, _ = generator.generate_samples()
+
+    assert [sample.group_ids[0] for sample in samples] == ["p0"]
+    assert rollout_metrics == {}
+
+
 def test_generate_samples_emits_short_batch_when_dataloader_exhausted(monkeypatch):
     generator = object.__new__(SamplesGenerator)
     generator.args = SimpleNamespace(
         rollout=SimpleNamespace(batch_size=4, n_samples_per_prompt=1, vllm_generate_batch_size=5),
-        algo=SimpleNamespace(dynamic_filtering_enable=False),
+        algo=SimpleNamespace(dynamic_filtering_enable=False, advantage=SimpleNamespace(estimator="reinforce")),
         ckpt=SimpleNamespace(warm_resume_rollouts=False),
         actor=SimpleNamespace(num_nodes=1, num_gpus_per_node=1),
         fsdp=SimpleNamespace(cp_size=1, tp_size=1),
@@ -185,11 +227,27 @@ def test_generate_eval_samples_defaults_to_rollout_batch_size(monkeypatch):
     assert dispatch_sizes == [2, 2, 1]
 
 
+def test_generate_eval_samples_keeps_incomplete_group_for_group_estimator(monkeypatch):
+    generator = object.__new__(SamplesGenerator)
+    generator.args = SimpleNamespace(
+        rollout=SimpleNamespace(batch_size=1, n_samples_per_prompt=2),
+        eval=SimpleNamespace(batch_size=1),
+        algo=SimpleNamespace(
+            dynamic_filtering_enable=False, advantage=SimpleNamespace(estimator="reinforce_baseline")
+        ),
+    )
+    _wire_eval_generator(generator, monkeypatch, num_prompts=1)
+
+    samples = generator.generate_eval_samples()
+
+    assert [sample.group_ids[0] for sample in samples] == ["p0"]
+
+
 def test_generate_samples_pool_persists_across_calls(monkeypatch):
     generator = object.__new__(SamplesGenerator)
     generator.args = SimpleNamespace(
         rollout=SimpleNamespace(batch_size=3, n_samples_per_prompt=1, vllm_generate_batch_size=5),
-        algo=SimpleNamespace(dynamic_filtering_enable=False),
+        algo=SimpleNamespace(dynamic_filtering_enable=False, advantage=SimpleNamespace(estimator="reinforce")),
         ckpt=SimpleNamespace(warm_resume_rollouts=False),
         actor=SimpleNamespace(num_nodes=1, num_gpus_per_node=1),
         fsdp=SimpleNamespace(cp_size=1, tp_size=1),
@@ -218,7 +276,7 @@ def test_generate_samples_terminates_when_dataset_not_divisible_by_batch(monkeyp
     generator = object.__new__(SamplesGenerator)
     generator.args = SimpleNamespace(
         rollout=SimpleNamespace(batch_size=3, n_samples_per_prompt=1, vllm_generate_batch_size=5),
-        algo=SimpleNamespace(dynamic_filtering_enable=False),
+        algo=SimpleNamespace(dynamic_filtering_enable=False, advantage=SimpleNamespace(estimator="reinforce")),
         ckpt=SimpleNamespace(warm_resume_rollouts=False),
         actor=SimpleNamespace(num_nodes=1, num_gpus_per_node=1),
         fsdp=SimpleNamespace(cp_size=1, tp_size=1),
@@ -250,7 +308,7 @@ def test_generate_samples_drops_epoch_tail_smaller_than_dp_groups(monkeypatch):
     generator = object.__new__(SamplesGenerator)
     generator.args = SimpleNamespace(
         rollout=SimpleNamespace(batch_size=3, n_samples_per_prompt=1, vllm_generate_batch_size=5),
-        algo=SimpleNamespace(dynamic_filtering_enable=False),
+        algo=SimpleNamespace(dynamic_filtering_enable=False, advantage=SimpleNamespace(estimator="reinforce")),
         ckpt=SimpleNamespace(warm_resume_rollouts=False),
         actor=SimpleNamespace(num_nodes=1, num_gpus_per_node=2),
         fsdp=SimpleNamespace(cp_size=1, tp_size=1),
@@ -279,7 +337,7 @@ def test_generator_keeps_no_checkpoint_state_and_resumes_from_dataloader(monkeyp
     generator = object.__new__(SamplesGenerator)
     generator.args = SimpleNamespace(
         rollout=SimpleNamespace(batch_size=3, n_samples_per_prompt=1, vllm_generate_batch_size=5),
-        algo=SimpleNamespace(dynamic_filtering_enable=False),
+        algo=SimpleNamespace(dynamic_filtering_enable=False, advantage=SimpleNamespace(estimator="reinforce")),
         ckpt=SimpleNamespace(warm_resume_rollouts=False),
         actor=SimpleNamespace(num_nodes=1, num_gpus_per_node=1),
         fsdp=SimpleNamespace(cp_size=1, tp_size=1),
@@ -311,7 +369,11 @@ def test_generate_samples_drops_filtered_groups_and_refills_their_slots(monkeypa
     generator = object.__new__(SamplesGenerator)
     generator.args = SimpleNamespace(
         rollout=SimpleNamespace(batch_size=2, n_samples_per_prompt=1, vllm_generate_batch_size=2),
-        algo=SimpleNamespace(dynamic_filtering_enable=True, dynamic_filtering_range=(0.0, 1.0)),
+        algo=SimpleNamespace(
+            dynamic_filtering_enable=True,
+            dynamic_filtering_range=(0.0, 1.0),
+            advantage=SimpleNamespace(estimator="reinforce_baseline"),
+        ),
     )
     generator.prompts_dataloader = _prompt_loader(10)
 


### PR DESCRIPTION
## Summary

Supersedes #48 with a smaller implementation against current `main`, following the rollout dispatch and regrouping changes in #108.

Group completeness was enforced only when dynamic filtering was enabled. A group estimator could therefore receive fewer than `n_samples_per_prompt` usable rollouts after a per-response drop, changing its intended prompt-level baseline.

Require complete groups when training with group estimators, while preserving partial groups for:

- per-sample estimators when dynamic filtering is disabled;
- evaluation, including when a group estimator is configured.

Existing dynamic-filtering behavior remains unchanged.

## Test plan

Regression coverage:
- Group estimator with dynamic filtering disabled rejects an incomplete group.
- Per-sample estimator with dynamic filtering disabled retains an incomplete group.
- Evaluation retains an incomplete group even when configured with a group estimator.

Validation:
- `python -m pytest -q tests/unit/test_samples_generator.py` — 19 passed.
- `python -m compileall -q molt examples/python tests` — passed.
- Ruff lint and format checks — passed.

The full suite could not collect locally because the test environment has PyTorch 2.4 and no Ray. Full-suite validation remains pending in the supported project container.