### PR TITLE
fix(ckpt): prune regular checkpoints by age, not by eval metric

### DIFF
--- a/molt/trainer/fsdp/checkpoint.py
+++ b/molt/trainer/fsdp/checkpoint.py
@@ -161,19 +161,6 @@ class CheckpointManager:
         path = self._get_ckpt_metric_path(ckpt_dir)
         self._atomic_write_json(path, {"metric_key": metric_key, "metric_value": metric_value})
 
-    def _read_ckpt_metric(self, ckpt_dir: str) -> float | None:
-        metric_path = self._get_ckpt_metric_path(ckpt_dir)
-        if not os.path.exists(metric_path):
-            return None
-        try:
-            with open(metric_path) as f:
-                payload = json.load(f)
-            value = payload.get("metric_value") if isinstance(payload, dict) else None
-            return None if value is None else float(value)
-        except (OSError, TypeError, ValueError, json.JSONDecodeError) as exc:
-            self.strategy.print(f"Warning: failed to read checkpoint metric from {metric_path}: {exc}")
-            return None
-
     @staticmethod
     def _dir_size(path: str) -> int:
         total = 0
@@ -278,14 +265,10 @@ class CheckpointManager:
             )
             if overflow_num == 0 and not overflow_mem:
                 break
-            candidates = sorted(
-                [(path, self._read_ckpt_metric(path), mtime) for path, mtime in regular_subdirs],
-                key=lambda item: (
-                    item[1] is not None,
-                    item[1] if item[1] is not None else float("-inf"),
-                    item[2],
-                ),
-            )
+            # Oldest first, as --ckpt.max_num documents. Ordering by metric.json instead made a
+            # checkpoint saved after an eval dip get evicted before older, better-scoring ones,
+            # so a chain could keep `latest` plus stale checkpoints and lose the recent fallbacks.
+            candidates = sorted(regular_subdirs, key=lambda item: item[1])
             if not candidates:
                 # regular_subdirs is exhausted (only current_tag/best* dirs remain, both
                 # protected from eviction) but max_mem is still over budget: warn instead of

--- a/tests/unit/test_checkpoint_client_state.py
+++ b/tests/unit/test_checkpoint_client_state.py
@@ -36,7 +36,7 @@ from molt.trainer.fsdp.checkpoint import CheckpointManager
 
 
 class _FakeStrategy:
-    def print(self, *msg):  # _read_ckpt_metric logs warnings through this
+    def print(self, *msg):  # CheckpointManager logs warnings through this
         pass
 
 
@@ -122,23 +122,11 @@ def test_load_missing_extra_state_is_empty(tmp_path):
 
 
 def test_metric_round_trip(tmp_path):
-    """metric.json: scalar coercion (python/torch/numpy) + read back as float."""
-    cm = _cm()
-    for raw, expected in [
-        (0.788, 0.788),
-        (torch.tensor(0.5), 0.5),
-        (None, None),
-    ]:
-        cm._write_ckpt_metric(str(tmp_path), raw, metric_key="eval/accuracy")
-        assert cm._read_ckpt_metric(str(tmp_path)) == expected
-
-    # numpy scalar (advantage/eval metrics are often numpy) coerces too
+    """metric.json: python/torch/numpy scalars land as plain JSON numbers (no type-tagging)."""
     import numpy as np
 
-    cm._write_ckpt_metric(str(tmp_path), np.float32(0.25), metric_key="k")
-    assert abs(cm._read_ckpt_metric(str(tmp_path)) - 0.25) < 1e-6
-
-    # the written file is plain JSON (no type-tagging)
-    with open(cm._get_ckpt_metric_path(str(tmp_path))) as f:
-        payload = json.load(f)
-    assert abs(payload["metric_value"] - 0.25) < 1e-6
+    cm = _cm()
+    for raw, expected in [(0.788, 0.788), (torch.tensor(0.5), 0.5), (None, None), (np.float32(0.25), 0.25)]:
+        cm._write_ckpt_metric(str(tmp_path), raw, metric_key="eval/accuracy")
+        with open(cm._get_ckpt_metric_path(str(tmp_path))) as f:
+            assert json.load(f)["metric_value"] == expected

--- a/tests/unit/test_prune_checkpoints.py
+++ b/tests/unit/test_prune_checkpoints.py
@@ -114,3 +114,18 @@ def test_no_warning_when_regular_eviction_satisfies_budget(tmp_path):
 
     assert set(os.listdir(root)) == {"step-2"}
     assert not strategy.messages
+
+
+def test_max_num_evicts_oldest_regardless_of_metric(tmp_path):
+    """--ckpt.max_num is age-based: a higher metric.json does not protect an older checkpoint."""
+    root = str(tmp_path)
+    cm = _cm()
+    for name, age_s, metric in [("step-1", 20, 0.9), ("step-2", 10, 0.5), ("step-3", 0, 0.5)]:
+        path = _make_ckpt_dir(root, name, 1024)
+        cm._write_ckpt_metric(path, metric, metric_key="eval_pass1")  # writing bumps the dir mtime, so age it after
+        stamp = time.time() - age_s
+        os.utime(path, (stamp, stamp))
+
+    cm._prune_checkpoints(root, current_tag="step-3", max_num=2, max_mem=0, is_best=False)
+
+    assert set(os.listdir(root)) == {"step-2", "step-3"}


### PR DESCRIPTION
--ckpt.max_num is documented as "older ones pruned", but _prune_checkpoints ordered regular eviction candidates by metric.json with mtime only as a tie-break. After an eval dip, checkpoints saved later were evicted before older, better-scoring ones, leaving `latest` plus stale checkpoints and no recent fallbacks. Sort by mtime only; drop the now-unused _read_ckpt_metric.