### PR TITLE
chore(deps): bump nemo-automodel f5303542 -> f7ccd6f7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ einops
 grpcio>=1.74.0
 huggingface_hub>=1.0.0
 jsonlines
-nemo-automodel @ git+https://github.com/NVIDIA-NeMo/Automodel.git@f530354246e951a05f8b856f7ce5a21ad7013ed8
+nemo-automodel @ git+https://github.com/NVIDIA-NeMo/Automodel.git@f7ccd6f7902634af34c2f31b3294ac250dc97670
 optree>=0.15.0
 packaging
 peft


### PR DESCRIPTION
13 upstream commits (2026-09-10 -> 2026-09-12): HF safetensors now load through DCP with TE `_extra_state` keys filtered out of the pre-shard key set, HF exports are sharded by size, `from_pretrained` accepts `dtype` and keeps `torch_dtype` as an alias, explicit tokenizer backend selection, DeepSeek-V4.1-Flash training support, Nemotron 3.5 Super VL LoRA recipe, PEFT export fixes. No dependency pin changes (transformers stays ==5.15.1; only the pytest-timeout test extra was added), so the image needs no other step.

Verified before bumping: every nemo_automodel symbol molt imports exists at the new commit (NeMoAutoModelFor* stay lazily exported; molt's optim dion/utils fallback is pre-existing), and dtype_from_str passes torch.dtype through so molt's torch_dtype= call site is unchanged. E2E: Qwen3.6-35B-A3B VLM RL (rl_qwen3_6_35b.sh, 2 nodes, image 0.1.8 with the new commit on EXTRA_PYTHONPATH, OFFLOAD_OPTIMIZER=1) loads through the new DCP path and trains with vllm_kl 2e-4.