### PR TITLE
fix(train): fold the trailing grad-accum remainder into the last window

### DIFF
--- a/examples/scripts/slurm/rl_glm5_2_753b.sh
+++ b/examples/scripts/slurm/rl_glm5_2_753b.sh
@@ -187,8 +187,8 @@ DASHBOARD_PORT="${DASHBOARD_PORT:-8265}"
 MAX_LENGTH="${MAX_LENGTH:-65536}"
 MAX_SAMPLES="${MAX_SAMPLES:-8192}"
 # rollout_batch_size = unique prompts dispatched per make_experience call.
-# Keep rollout_batch_size * n_samples >= train_batch_size or the policy_train
-# loop drops trailing microbatches; the default sizes one rollout per grad step.
+# The trainer steps once per train_batch_size window and folds a remainder into the
+# last one (no samples dropped); the default sizes one rollout per grad step.
 ROLLOUT_BATCH_SIZE="${ROLLOUT_BATCH_SIZE:-16}"
 ROLLOUT_GENERATE_BATCH_SIZE="${ROLLOUT_GENERATE_BATCH_SIZE:-8}"
 N_SAMPLES_PER_PROMPT="${N_SAMPLES_PER_PROMPT:-8}"

--- a/examples/scripts/slurm/rl_omni3_30b.sh
+++ b/examples/scripts/slurm/rl_omni3_30b.sh
@@ -169,8 +169,8 @@ DASHBOARD_PORT="${DASHBOARD_PORT:-8265}"
 MAX_LENGTH="${MAX_LENGTH:-65536}"
 MAX_SAMPLES="${MAX_SAMPLES:-8192}"
 # rollout_batch_size = unique prompts dispatched per make_experience call.
-# Keep rollout_batch_size * n_samples >= train_batch_size or the policy_train
-# loop drops trailing microbatches; the default sizes one rollout per grad step.
+# The trainer steps once per train_batch_size window and folds a remainder into the
+# last one (no samples dropped); the default sizes one rollout per grad step.
 ROLLOUT_BATCH_SIZE="${ROLLOUT_BATCH_SIZE:-16}"
 ROLLOUT_GENERATE_BATCH_SIZE="${ROLLOUT_GENERATE_BATCH_SIZE:-8}"
 N_SAMPLES_PER_PROMPT="${N_SAMPLES_PER_PROMPT:-8}"

--- a/examples/scripts/slurm/rl_qwen3_4b.sh
+++ b/examples/scripts/slurm/rl_qwen3_4b.sh
@@ -107,9 +107,8 @@ DASHBOARD_PORT="${DASHBOARD_PORT:-8265}"
 MAX_LENGTH="${MAX_LENGTH:-65536}"
 MAX_SAMPLES="${MAX_SAMPLES:-8192}"
 # rollout_batch_size = unique prompts the trainer dispatches per
-# `make_experience` call. The trainer's policy_train loop drops trailing
-# microbatches when `microbatches_per_rollout < grad_accum`, so size
-# `rollout_batch_size * n_samples >= train_batch_size` to avoid no-op steps.
+# `make_experience` call. The trainer steps once per `train_batch_size` window; a
+# remainder joins the last window, so no samples are dropped whatever the ratio.
 # Default sized for one rollout = one full grad-accum window:
 #   rollout_batch_size * n_samples = train_batch_size  (1 rollout per step)
 ROLLOUT_BATCH_SIZE="${ROLLOUT_BATCH_SIZE:-16}"

--- a/examples/scripts/slurm/rl_qwen3_6_35b.sh
+++ b/examples/scripts/slurm/rl_qwen3_6_35b.sh
@@ -166,9 +166,8 @@ DASHBOARD_PORT="${DASHBOARD_PORT:-8265}"
 MAX_LENGTH="${MAX_LENGTH:-65536}"
 MAX_SAMPLES="${MAX_SAMPLES:-8192}"
 # rollout_batch_size = unique prompts the trainer dispatches per
-# `make_experience` call. The trainer's policy_train loop drops trailing
-# microbatches when `microbatches_per_rollout < grad_accum`, so size
-# `rollout_batch_size * n_samples >= train_batch_size` to avoid no-op steps.
+# `make_experience` call. The trainer steps once per `train_batch_size` window; a
+# remainder joins the last window, so no samples are dropped whatever the ratio.
 # Default sized for one rollout = one full grad-accum window:
 #   rollout_batch_size * n_samples = train_batch_size  (1 rollout per step)
 ROLLOUT_BATCH_SIZE="${ROLLOUT_BATCH_SIZE:-16}"

--- a/molt/cli/train_rl_ray.py
+++ b/molt/cli/train_rl_ray.py
@@ -769,8 +769,7 @@ if __name__ == "__main__":
             "batch and run a single optimizer step at the final microbatch, instead of splitting "
             "the rollout into several train.batch_size / grad-accum windows. Needed for multi-turn "
             "flatten, where the per-rollout sample count is variable and a fixed train.batch_size "
-            "would make every step after the first off-policy and drop the trailing samples. "
-            "Requires --train.max_epochs 1."
+            "would make every step after the first off-policy. Requires --train.max_epochs 1."
         ),
     )
 

--- a/molt/trainer/algorithm/replay_buffer.py
+++ b/molt/trainer/algorithm/replay_buffer.py
@@ -107,24 +107,17 @@ class NaiveReplayBuffer:
             num_steps = 1 if sample_lengths else 0
         else:
             local_train_batch_size = args.train.batch_size // dp_size
-            # Async generation can deliver a short buffer at episode boundaries.
-            # Also, multi-turn agents may flatten to a variable number of samples
-            # per prompt — use the actual buffer size, not the formula.
-            num_steps = len(sample_lengths) // local_train_batch_size
-            # balance_experiences only equalizes the per-rank count to a multiple
-            # of dp_size, not of local_train_batch_size, so a remainder here is
-            # dropped from this update. Surface it instead of dropping silently.
-            dropped = len(sample_lengths) - num_steps * local_train_batch_size
-            if dropped:
-                strategy.print(
-                    f"[ReplayBuffer] dropping {dropped} trailing sample(s) per rank that don't fill a "
-                    f"{local_train_batch_size}-sample train batch (buffer={len(sample_lengths)})."
-                )
+            # Async generation can deliver a short buffer at episode boundaries, and
+            # multi-turn agents flatten to a variable number of samples per prompt, so
+            # use the actual buffer size; a remainder joins the last window (see below).
+            num_steps = max(1, len(sample_lengths) // local_train_batch_size) if sample_lengths else 0
 
         # split by train_batch_size, sync num_microbatches across dp
+        windows = [(i * local_train_batch_size, (i + 1) * local_train_batch_size) for i in range(num_steps)]
+        if windows:  # the last window absorbs the remainder, as the on-policy path takes the whole buffer
+            windows[-1] = (windows[-1][0], len(sample_lengths))
         num_microbatches = []
-        for i in range(num_steps):
-            start, end = i * local_train_batch_size, (i + 1) * local_train_batch_size
+        for start, end in windows:
             num_microbatches.append(
                 get_minimum_num_micro_batch_size(
                     sample_lengths[start:end],
@@ -141,8 +134,7 @@ class NaiveReplayBuffer:
         # balance the number of microbatches across steps
         micro_batch_indices = []
         data_partitions = []
-        for i, num_mbs in enumerate(num_microbatches):
-            start, end = i * local_train_batch_size, (i + 1) * local_train_batch_size
+        for (start, end), num_mbs in zip(windows, num_microbatches):
             samples = sample_lengths[start:end]
             partitions = get_seqlen_balanced_partitions(samples, num_mbs, equal_size=False)  # List[List[int]], index
             for j in range(num_mbs):

--- a/molt/trainer/rl_trainer.py
+++ b/molt/trainer/rl_trainer.py
@@ -116,8 +116,12 @@ def prepare_datasets(strategy, tokenizer):
         rounds = -(-len(prompts_dataset) // args.rollout.batch_size)
         max_steps = rounds * args.train.num_episodes * args.train.max_epochs
     else:
-        steps = -(-len(prompts_dataset) * args.rollout.n_samples_per_prompt // args.train.batch_size)
-        max_steps = steps * args.train.num_episodes * args.train.max_epochs
+        # Each rollout round trains on its own buffer and its last window absorbs the
+        # remainder (a buffer under train.batch_size is one step, like on-policy), so
+        # count max(1, floor) steps per round rather than one global ceil.
+        rounds = -(-len(prompts_dataset) // args.rollout.batch_size)
+        steps_per_round = max(1, args.rollout.batch_size * args.rollout.n_samples_per_prompt // args.train.batch_size)
+        max_steps = rounds * steps_per_round * args.train.num_episodes * args.train.max_epochs
     return prompts_dataloader, eval_dataloader, max_steps
 
 

--- a/molt/trainer/workers/critic_actor.py
+++ b/molt/trainer/workers/critic_actor.py
@@ -135,10 +135,6 @@ class CriticTrainer:
             max_steps = len(dataloader)
             if self.args.train.force_on_policy and not dynamic:
                 accum_steps = max(max_steps, 1)
-            elif not dynamic:
-                remainder = max_steps % accum_steps
-                if remainder:
-                    max_steps -= remainder
 
             # Same window / global-token-mean contract as PolicyTrainer.policy_train.
             window = []
@@ -146,9 +142,11 @@ class CriticTrainer:
                 if step >= max_steps:
                     break
                 window.append(experience)
-                window_end = (
-                    bool(self.replay_buffer.dynamic_optimizer_step[step]) if dynamic else len(window) == accum_steps
-                )
+                if dynamic:
+                    window_end = bool(self.replay_buffer.dynamic_optimizer_step[step])
+                else:  # the last window absorbs the remainder, as in policy_train
+                    remaining = max_steps - step - 1
+                    window_end = remaining == 0 or (len(window) == accum_steps and remaining >= accum_steps)
                 if not window_end:
                     continue
                 local_tokens = sum(exp.action_mask.sum() for exp in window)

--- a/molt/trainer/workers/policy_actor.py
+++ b/molt/trainer/workers/policy_actor.py
@@ -280,16 +280,6 @@ class PolicyTrainer:
                 # update is computed from exactly the data the current weights
                 # generated. max_epochs is asserted == 1, so this is one step.
                 accum_steps = max(max_steps, 1)
-            elif not dynamic:
-                # Only run complete accumulation windows; partial windows leave
-                # gradients live because optimizer_step() has not stepped yet.
-                remainder = max_steps % accum_steps
-                if remainder:
-                    max_steps -= remainder
-                    self.strategy.print(
-                        f"[PolicyRL] dropping {remainder} trailing actor microbatches "
-                        f"(< grad_accum={accum_steps}) to avoid partial gradients."
-                    )
             # slime global token-mean: every microbatch of one optimizer-step
             # batch ("window") shares a single token denominator summed over all
             # its microbatches and all DP ranks. Buffer the window, count its
@@ -302,7 +292,10 @@ class PolicyTrainer:
                 if dynamic:
                     window_end = bool(self.replay_buffer.dynamic_optimizer_step[step])
                 else:
-                    window_end = len(window) == accum_steps
+                    # The last window absorbs a remainder smaller than grad_accum (as the
+                    # on-policy path takes the whole buffer), so no sample is dropped.
+                    remaining = max_steps - step - 1
+                    window_end = remaining == 0 or (len(window) == accum_steps and remaining >= accum_steps)
                 if not window_end:
                     continue
                 local_tokens = sum(exp.action_mask.sum() for exp in window)


### PR DESCRIPTION
With force_on_policy off, a rollout buffer that is not a multiple of train.batch_size lost its trailing samples: the actor/critic loops cut the epoch at the last complete grad-accum window and setup_dynamic_batch floored the step count, both printing a "dropping N trailing ..." notice. Nothing numerical required that — every window normalizes by its own global token count (scale_loss_by_accumulation=False) and balance_experiences keeps per-rank counts equal, so a larger last window is a valid, lockstep optimizer step. Let the last window absorb the remainder, the same way the on-policy path takes the whole buffer (a buffer under train.batch_size becomes exactly one step), and size the LR horizon as max(1, floor) steps per rollout round to match. Users who want strictly complete batches keep the existing knobs (dynamic filtering, rollout sizing); the default drops nothing.