### PR TITLE
fix(rollout): count runner exceptions as drops

### DIFF
--- a/molt/trainer/rollout/router.py
+++ b/molt/trainer/rollout/router.py
@@ -373,6 +373,7 @@ class AgentRunnerActor:
         for r in await asyncio.gather(*tasks, return_exceptions=True):  # a failed rollout must not sink the group
             if isinstance(r, BaseException):
                 print(f"[runner] dropping failed rollout in group {group_id}: {r!r}", flush=True)
+                results.append((None, "runner_error"))
                 continue
             rollout_id = uuid4().hex
             for traj in r if isinstance(r, list) else [r]:

--- a/tests/unit/test_router.py
+++ b/tests/unit/test_router.py
@@ -266,3 +266,22 @@ def test_agent_runner_actor_init_is_synchronous():
     """Ray actor constructors are synchronous; an async __init__ would not be awaited."""
     actor_cls = getattr(AgentRunnerActor, "__ray_actor_class__", AgentRunnerActor)
     assert not inspect.iscoroutinefunction(actor_cls.__init__)
+
+
+def test_agent_runner_reports_each_failed_rollout():
+    class _FailingRunner:
+        async def execute(self, **kwargs):
+            raise RuntimeError("agent failed")
+
+    actor_cls = getattr(AgentRunnerActor, "__ray_actor_class__", AgentRunnerActor)
+    actor = object.__new__(actor_cls)
+    actor._runner = _FailingRunner()
+    actor._tokenizer = None
+    actor._client = None
+    actor._media_ids = set()
+
+    results = asyncio.run(
+        actor.run_group("prompt", "label", None, SimpleNamespace(), 128, 2, group_id="group")
+    )
+
+    assert results == [(None, "runner_error"), (None, "runner_error")]


### PR DESCRIPTION
## Summary

Agent or environment exceptions during rollout were logged and dropped, but the runner returned no drop record. This left the failures out of `rollout/dropped/*` metrics even though training continued with fewer usable rollouts.

Return a `runner_error` drop reason for each failed rollout so the existing drop-accounting path reports it.

## Test plan

- Agent runner reports one `runner_error` record per failed rollout.
- `python -m pytest -q tests/unit/test_router.py` (13 passed with Ray stubbed locally)
- `python -m compileall -q molt examples/python tests`
- `bash -n examples/scripts/*.sh examples/scripts/quick_start/*.sh examples/scripts/slurm/*.sh`
- `git diff --check`

Upstream CI will run the test with the real Ray dependency.
